### PR TITLE
allow specifying gpus explicitly

### DIFF
--- a/deploy/3-mpi-operator.yaml
+++ b/deploy/3-mpi-operator.yaml
@@ -18,8 +18,7 @@ spec:
       serviceAccountName: mpi-operator
       containers:
       - name: mpi-operator
-#        image: mpioperator/mpi-operator:latest
-        image: rongou/mpi-operator:latest
+        image: mpioperator/mpi-operator:latest
         args: [
           "--gpus-per-node", "8",
           "--kubectl-delivery-image",

--- a/deploy/3-mpi-operator.yaml
+++ b/deploy/3-mpi-operator.yaml
@@ -18,7 +18,8 @@ spec:
       serviceAccountName: mpi-operator
       containers:
       - name: mpi-operator
-        image: mpioperator/mpi-operator:latest
+#        image: mpioperator/mpi-operator:latest
+        image: rongou/mpi-operator:latest
         args: [
           "--gpus-per-node", "8",
           "--kubectl-delivery-image",

--- a/examples/tensorflow-benchmarks-custom.yaml
+++ b/examples/tensorflow-benchmarks-custom.yaml
@@ -1,13 +1,16 @@
 # This file shows how to run multi-node training benchmarks using an MPIJob,
-# letting the operator decide on how best to allocate GPUs.
+# specifying GPUs explicitly.
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:
-  name: tensorflow-benchmarks-1-gpu
+  name: tensorflow-benchmarks-8
 spec:
-  gpus: 1
+  replicas: 8
   template:
     spec:
       containers:
       - image: mpioperator/tensorflow-benchmarks:latest
         name: tensorflow-benchmarks
+        resources:
+          limits:
+            nvidia.com/gpu: 1

--- a/examples/tensorflow-benchmarks-custom.yaml
+++ b/examples/tensorflow-benchmarks-custom.yaml
@@ -1,5 +1,5 @@
 # This file shows how to run multi-node training benchmarks using an MPIJob,
-# specifying GPUs explicitly.
+# specifying GPUs explicitly per replica.
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:

--- a/examples/tensorflow-benchmarks-custom.yaml
+++ b/examples/tensorflow-benchmarks-custom.yaml
@@ -3,9 +3,9 @@
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:
-  name: tensorflow-benchmarks-8
+  name: tensorflow-benchmarks-16-custom
 spec:
-  replicas: 8
+  replicas: 4
   template:
     spec:
       containers:
@@ -13,4 +13,4 @@ spec:
         name: tensorflow-benchmarks
         resources:
           limits:
-            nvidia.com/gpu: 1
+            nvidia.com/gpu: 4

--- a/examples/tensorflow-benchmarks.yaml
+++ b/examples/tensorflow-benchmarks.yaml
@@ -1,5 +1,15 @@
 # This file shows how to run multi-node training benchmarks using an MPIJob,
 # letting the operator decide on how best to allocate GPUs.
+#
+# In this mode, the operator assumes all nodes have the same number of GPUs.
+# If `gpus` is bigger than the number of GPUs per node, then only whole nodes
+# can be allocated.
+#
+# For example, if each node has 8 GPUs, the valid `gpus` values are:
+# 1, 2, 4, 8, 16, 24, 32, ...or any multiple of 8.
+#
+# If you need more flexibility in allocating GPUs, you can use the alternative
+# mode to specify `replicas` and GPU resource limit explicitly.
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:

--- a/examples/tensorflow-benchmarks.yaml
+++ b/examples/tensorflow-benchmarks.yaml
@@ -3,9 +3,9 @@
 apiVersion: kubeflow.org/v1alpha1
 kind: MPIJob
 metadata:
-  name: tensorflow-benchmarks-1-gpu
+  name: tensorflow-benchmarks-16
 spec:
-  gpus: 1
+  gpus: 16
   template:
     spec:
       containers:

--- a/pkg/apis/kubeflow/v1alpha1/types.go
+++ b/pkg/apis/kubeflow/v1alpha1/types.go
@@ -39,8 +39,15 @@ type MPIJobList struct {
 
 type MPIJobSpec struct {
 	// Specifies the desired number of GPUs the MPIJob should run on.
+	// Mutually exclusive with the `Replicas` field.
 	// +optional
 	GPUs *int32 `json:"gpus,omitempty"`
+
+	// Specifies the desired number of replicas the MPIJob should run on.
+	// The `PodSpec` should specify the number of GPUs.
+	// Mutually exclusive with the `GPUs` field.
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Describes the pod that will be created when executing an MPIJob.
 	Template corev1.PodTemplateSpec `json:"template,omitempty"`

--- a/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
@@ -95,6 +95,15 @@ func (in *MPIJobSpec) DeepCopyInto(out *MPIJobSpec) {
 			**out = **in
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int32)
+			**out = **in
+		}
+	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
 }


### PR DESCRIPTION
Also allocate all gpus to the worker; the launcher no longer needs gpus.

closes #5 
closes #6 