### PR TITLE
glog uses -alsologtostderr

### DIFF
--- a/deploy/3-mpi-operator.yaml
+++ b/deploy/3-mpi-operator.yaml
@@ -20,6 +20,7 @@ spec:
       - name: mpi-operator
         image: mpioperator/mpi-operator:latest
         args: [
+          "-alsologtostderr",
           "--gpus-per-node", "8",
           "--kubectl-delivery-image",
           "mpioperator/kubectl-delivery:latest"


### PR DESCRIPTION
Found that mpi-operator doesn't log to std by default, this causes "kubectl logs" doesn't retrieve the logs. 
Think it's more convenient as the other operators do, like the tf-operator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/64)
<!-- Reviewable:end -->
