### PR TITLE
Allow users to pass resync period for informers

### DIFF
--- a/cmd/mpi-operator/main.go
+++ b/cmd/mpi-operator/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"time"
 
 	"github.com/golang/glog"
 	kubeinformers "k8s.io/client-go/informers"
@@ -34,6 +35,7 @@ var (
 	gpusPerNode          int
 	kubectlDeliveryImage string
 	namespace            string
+	resyncPeriod         time.Duration
 )
 
 func main() {
@@ -59,11 +61,11 @@ func main() {
 
 	var kubeInformerFactory kubeinformers.SharedInformerFactory
 	if namespace == "" {
-		kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+		kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClient, resyncPeriod)
 	} else {
-		kubeInformerFactory = kubeinformers.NewFilteredSharedInformerFactory(kubeClient, 0, namespace, nil)
+		kubeInformerFactory = kubeinformers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod, namespace, nil)
 	}
-	kubeflowInformerFactory := informers.NewSharedInformerFactory(kubeflowClient, 0)
+	kubeflowInformerFactory := informers.NewSharedInformerFactory(kubeflowClient, resyncPeriod)
 
 	controller := controllers.NewMPIJobController(
 		kubeClient,
@@ -92,4 +94,9 @@ func init() {
 	flag.IntVar(&gpusPerNode, "gpus-per-node", 1, "The maximum number of GPUs available per node.")
 	flag.StringVar(&kubectlDeliveryImage, "kubectl-delivery-image", "", "The container image used to deliver the kubectl binary.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace used for Kubernetes to obtain the listers.")
+	flag.DurationVar(
+		&resyncPeriod,
+		"resync-period",
+		0,
+		"The resync period used for Kubernetes to obtain the listers. Defaults to 0 to never resync.")
 }


### PR DESCRIPTION
Sometimes users need to control the resync period for informers. The default is kept to be 0 (don't resync at all) in case that there are many MPIJobs for large clusters where resync might take a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/67)
<!-- Reviewable:end -->
