### PR TITLE
Support ActiveDeadlineSeconds that takes precedence over BackoffLimit

### DIFF
--- a/pkg/apis/kubeflow/v1alpha1/types.go
+++ b/pkg/apis/kubeflow/v1alpha1/types.go
@@ -57,7 +57,7 @@ type MPIJobSpec struct {
 	// the job may be active before the system tries to terminate it.
 	// Note that this takes precedence over `BackoffLimit` field.
 	// +optional
-	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 
 	// Specifies the desired number of replicas the MPIJob should run on.
 	// The `PodSpec` should specify the number of GPUs.

--- a/pkg/apis/kubeflow/v1alpha1/types.go
+++ b/pkg/apis/kubeflow/v1alpha1/types.go
@@ -48,10 +48,16 @@ type MPIJobSpec struct {
 	// +optional
 	LauncherOnMaster bool `json:"launcherOnMaster,omitempty"`
 
-	// Optional number of retries before marking this job failed.
+	// Specifies the number of retries before marking this job failed.
 	// Defaults to 6
 	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+
+	// Specifies the duration in seconds relative to the start time that
+	// the job may be active before the system tries to terminate it.
+	// Note that this takes precedence over `BackoffLimit` field.
+	// +optional
+	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
 
 	// Specifies the desired number of replicas the MPIJob should run on.
 	// The `PodSpec` should specify the number of GPUs.

--- a/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
@@ -98,7 +98,7 @@ func (in *MPIJobSpec) DeepCopyInto(out *MPIJobSpec) {
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int32)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Replicas != nil {

--- a/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeflow/v1alpha1/zz_generated.deepcopy.go
@@ -96,6 +96,11 @@ func (in *MPIJobSpec) DeepCopyInto(out *MPIJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)

--- a/pkg/controllers/mpi_job_controller.go
+++ b/pkg/controllers/mpi_job_controller.go
@@ -907,7 +907,7 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, gpus int) *appsv1
 		},
 	})
 
-	// set default BackoofLimit
+	// set default BackoffLimit
 	if mpiJob.Spec.BackoffLimit == nil {
 		mpiJob.Spec.BackoffLimit = new(int32)
 		*mpiJob.Spec.BackoffLimit = 6
@@ -1070,8 +1070,9 @@ func newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryImage string) *batchv1.
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: mpiJob.Spec.BackoffLimit,
-			Template:     *podSpec,
+			BackoffLimit:          mpiJob.Spec.BackoffLimit,
+			ActiveDeadlineSeconds: mpiJob.Spec.ActiveDeadlineSeconds,
+			Template:              *podSpec,
 		},
 	}
 }


### PR DESCRIPTION
If the retried jobs take a long time to complete/fail due to reasons like slow network performance, `ActiveDeadlineSeconds` is a good solution to handle this situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/81)
<!-- Reviewable:end -->
