### PR TITLE
Update kubectl version in kubectl-delivery

### DIFF
--- a/cmd/kubectl-delivery/Dockerfile
+++ b/cmd/kubectl-delivery/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.7 AS build
 
 # Install kubectl.
-ENV K8S_VERSION v1.10.3
+ENV K8S_VERSION v1.13.1
 RUN apk add --no-cache wget
 RUN wget -q https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl


### PR DESCRIPTION
This is to be consistent with the k8s version in `Gopkg.toml`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/83)
<!-- Reviewable:end -->
