### PR TITLE
Remove unnecessary minAvailableWorkerReplicas check

### DIFF
--- a/pkg/controllers/mpi_job_controller.go
+++ b/pkg/controllers/mpi_job_controller.go
@@ -600,11 +600,6 @@ func allocateProcessingUnits(
 // getOrCreatePDB will create a PDB for gang scheduling by kube-batch.
 func (c *MPIJobController) getOrCreatePDB(mpiJob *kubeflow.MPIJob, minAvailableWorkerReplicas int) (*policyv1beta1.PodDisruptionBudget, error) {
 
-	// Gang scheduling is only suitable for distributed training
-	if minAvailableWorkerReplicas < 2 {
-		return nil, nil
-	}
-
 	pdb, err := c.pdbLister.PodDisruptionBudgets(mpiJob.Namespace).Get(mpiJob.Name + pdbSuffix)
 	// If the PDB doesn't exist, we'll create it.
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
This check is not necessary and could cause problems (e.g. jobs are always pending and PDB is not created when # of replicas < 2). Also kube-batch supports single pod now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/91)
<!-- Reviewable:end -->
