### PR TITLE
Added missing labels when creating configmaps

### DIFF
--- a/pkg/controllers/mpi_job_controller.go
+++ b/pkg/controllers/mpi_job_controller.go
@@ -872,6 +872,9 @@ shift
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mpiJob.Name + configSuffix,
 			Namespace: mpiJob.Namespace,
+			Labels: map[string]string{
+				"app": mpiJob.Name,
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(mpiJob, kubeflow.SchemeGroupVersionKind),
 			},


### PR DESCRIPTION
`Labels` is missing from `ObjectMeta` when creating configmaps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/94)
<!-- Reviewable:end -->
