### PR TITLE
 Use kube-batch as scheduler by default when gang-scheduling is enabled

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -125,32 +125,6 @@
   version = "v1.1.5"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d6ec8799b1f86397187016bfc7e129e51726e9b46106b0ca52f5478f4279a4e8"
-  name = "github.com/kubeflow/mpi-operator"
-  packages = [
-    "pkg/apis/kubeflow/v1alpha1",
-    "pkg/apis/kubeflow/v1alpha2",
-    "pkg/client/clientset/versioned",
-    "pkg/client/clientset/versioned/fake",
-    "pkg/client/clientset/versioned/scheme",
-    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha1",
-    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha1/fake",
-    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha2",
-    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha2/fake",
-    "pkg/client/informers/externalversions",
-    "pkg/client/informers/externalversions/internalinterfaces",
-    "pkg/client/informers/externalversions/kubeflow",
-    "pkg/client/informers/externalversions/kubeflow/v1alpha1",
-    "pkg/client/informers/externalversions/kubeflow/v1alpha2",
-    "pkg/client/listers/kubeflow/v1alpha1",
-    "pkg/client/listers/kubeflow/v1alpha2",
-    "pkg/controllers",
-  ]
-  pruneopts = ""
-  revision = "bb15f1bc8468a7c9e983c49f8f15d80311c371e9"
-
-[[projects]]
   digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -125,6 +125,32 @@
   version = "v1.1.5"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6ec8799b1f86397187016bfc7e129e51726e9b46106b0ca52f5478f4279a4e8"
+  name = "github.com/kubeflow/mpi-operator"
+  packages = [
+    "pkg/apis/kubeflow/v1alpha1",
+    "pkg/apis/kubeflow/v1alpha2",
+    "pkg/client/clientset/versioned",
+    "pkg/client/clientset/versioned/fake",
+    "pkg/client/clientset/versioned/scheme",
+    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha1",
+    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha1/fake",
+    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha2",
+    "pkg/client/clientset/versioned/typed/kubeflow/v1alpha2/fake",
+    "pkg/client/informers/externalversions",
+    "pkg/client/informers/externalversions/internalinterfaces",
+    "pkg/client/informers/externalversions/kubeflow",
+    "pkg/client/informers/externalversions/kubeflow/v1alpha1",
+    "pkg/client/informers/externalversions/kubeflow/v1alpha2",
+    "pkg/client/listers/kubeflow/v1alpha1",
+    "pkg/client/listers/kubeflow/v1alpha2",
+    "pkg/controllers",
+  ]
+  pruneopts = ""
+  revision = "bb15f1bc8468a7c9e983c49f8f15d80311c371e9"
+
+[[projects]]
   digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -157,12 +183,28 @@
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = ""
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -632,6 +674,24 @@
   analyzer-version = 1
   input-imports = [
     "github.com/golang/glog",
+    "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v1alpha1",
+    "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v1alpha2",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/fake",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/scheme",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/typed/kubeflow/v1alpha1",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/typed/kubeflow/v1alpha1/fake",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/typed/kubeflow/v1alpha2",
+    "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/typed/kubeflow/v1alpha2/fake",
+    "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions",
+    "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions/internalinterfaces",
+    "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions/kubeflow",
+    "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions/kubeflow/v1alpha1",
+    "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions/kubeflow/v1alpha2",
+    "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha1",
+    "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha2",
+    "github.com/kubeflow/mpi-operator/pkg/controllers",
+    "github.com/stretchr/testify/assert",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -199,22 +199,9 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
-  name = "github.com/stretchr/objx"
-  packages = ["."]
-  pruneopts = ""
-  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
-  version = "v0.1.1"
-
-[[projects]]
   digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
-  packages = [
-    ".",
-    "assert",
-    "http",
-    "mock",
-  ]
+  packages = ["assert"]
   pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
@@ -704,7 +691,6 @@
     "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha1",
     "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha2",
     "github.com/kubeflow/mpi-operator/pkg/controllers",
-    "github.com/stretchr/testify",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -199,9 +199,22 @@
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  pruneopts = ""
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
   digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    ".",
+    "assert",
+    "http",
+    "mock",
+  ]
   pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
@@ -691,6 +704,7 @@
     "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha1",
     "github.com/kubeflow/mpi-operator/pkg/client/listers/kubeflow/v1alpha2",
     "github.com/kubeflow/mpi-operator/pkg/controllers",
+    "github.com/stretchr/testify",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,4 +16,6 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
   name = "k8s.io/client-go"
   version = "kubernetes-1.13.2"
 
-
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"

--- a/pkg/controllers/mpi_job_controller.go
+++ b/pkg/controllers/mpi_job_controller.go
@@ -1061,7 +1061,9 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, processingUnits i
 	//add SchedulerName to podSpec
 	if enableGangScheduling {
 		if podSpec.Spec.SchedulerName != "" && podSpec.Spec.SchedulerName != gangSchedulerName {
-
+			errMsg := fmt.Sprintf(
+				"%s scheduler is specified when gang-scheduling is enabled and it will not be overwritten", podSpec.Spec.SchedulerName)
+			glog.Warning(errMsg)
 		} else {
 			podSpec.Spec.SchedulerName = gangSchedulerName
 		}

--- a/pkg/controllers/mpi_job_controller.go
+++ b/pkg/controllers/mpi_job_controller.go
@@ -96,6 +96,9 @@ const (
 
 	// LabelNodeRoleMaster specifies that a node is a master
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+
+	// gang scheduler name.
+	gangSchedulerName = "kube-batch"
 )
 
 // MPIJobController is the controller implementation for MPIJob resources.
@@ -727,7 +730,7 @@ func (c *MPIJobController) getOrCreateWorkerStatefulSet(mpiJob *kubeflow.MPIJob,
 	worker, err := c.statefulSetLister.StatefulSets(mpiJob.Namespace).Get(mpiJob.Name + workerSuffix)
 	// If the StatefulSet doesn't exist, we'll create it.
 	if errors.IsNotFound(err) && workerReplicas > 0 {
-		worker, err = c.kubeClient.AppsV1().StatefulSets(mpiJob.Namespace).Create(newWorker(mpiJob, int32(workerReplicas), processingUnitsPerWorker, processingResourceType))
+		worker, err = c.kubeClient.AppsV1().StatefulSets(mpiJob.Namespace).Create(newWorker(mpiJob, int32(workerReplicas), processingUnitsPerWorker, processingResourceType, c.enableGangScheduling))
 	}
 	// If an error occurs during Get/Create, we'll requeue the item so we
 	// can attempt processing again later. This could have been caused by a
@@ -746,7 +749,7 @@ func (c *MPIJobController) getOrCreateWorkerStatefulSet(mpiJob *kubeflow.MPIJob,
 
 	// If the worker is out of date, update the worker.
 	if worker != nil && int(*worker.Spec.Replicas) != workerReplicas {
-		worker, err = c.kubeClient.AppsV1().StatefulSets(mpiJob.Namespace).Update(newWorker(mpiJob, int32(workerReplicas), processingUnitsPerWorker, processingResourceType))
+		worker, err = c.kubeClient.AppsV1().StatefulSets(mpiJob.Namespace).Update(newWorker(mpiJob, int32(workerReplicas), processingUnitsPerWorker, processingResourceType, c.enableGangScheduling))
 		// If an error occurs during Update, we'll requeue the item so we can
 		// attempt processing again later. This could have been caused by a
 		// temporary network failure, or any other transient reason.
@@ -1001,7 +1004,7 @@ func convertProcessingResourceType(processingResourceType string) corev1.Resourc
 // newWorker creates a new worker StatefulSet for an MPIJob resource. It also
 // sets the appropriate OwnerReferences on the resource so handleObject can
 // discover the MPIJob resource that 'owns' it.
-func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, processingUnits int, processingResourceType string) *appsv1.StatefulSet {
+func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, processingUnits int, processingResourceType string, enableGangScheduling bool) *appsv1.StatefulSet {
 	labels := map[string]string{
 		labelGroupName:   "kubeflow.org",
 		labelMPIJobName:  mpiJob.Name,
@@ -1054,6 +1057,15 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, processingUnits i
 			},
 		},
 	})
+
+	//add SchedulerName to podSpec
+	if enableGangScheduling {
+		if podSpec.Spec.SchedulerName != "" && podSpec.Spec.SchedulerName != gangSchedulerName {
+
+		} else {
+			podSpec.Spec.SchedulerName = gangSchedulerName
+		}
+	}
 
 	// set default BackoffLimit
 	if mpiJob.Spec.BackoffLimit == nil {

--- a/pkg/controllers/mpi_job_controller_test.go
+++ b/pkg/controllers/mpi_job_controller_test.go
@@ -804,4 +804,20 @@ func TestEnableGangScheduling(t *testing.T) {
 	assert.Equal(t, gangSchedulerName, worker.Spec.Template.Spec.SchedulerName)
 }
 
+func TestEnableGangSchedulingWithDupScheduler(t *testing.T) {
+	f := newFixture(t)
+	startTime := metav1.Now()
+	completionTime := metav1.Now()
+
+	mpiJob := newMPIJobWithCPUs("test", int32Ptr(16), &startTime, &completionTime)
+	f.setUpMPIJob(mpiJob)
+	mpiJob.Spec.Template.Spec.SchedulerName = "xyz"
+
+	f.setUpConfigMap(newConfigMap(mpiJob, 2, 8))
+	f.setUpRbac(mpiJob, 2)
+
+	worker := newWorker(mpiJob, 2, 8, cpuResourceName, true)
+	assert.Equal(t, "xyz", worker.Spec.Template.Spec.SchedulerName)
+}
+
 func int32Ptr(i int32) *int32 { return &i }

--- a/pkg/controllers/mpi_job_controller_test.go
+++ b/pkg/controllers/mpi_job_controller_test.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -550,7 +551,7 @@ func TestLauncherDoesNotExist(t *testing.T) {
 	expRoleBinding := newLauncherRoleBinding(mpiJob)
 	f.expectCreateRoleBindingAction(expRoleBinding)
 
-	expWorker := newWorker(mpiJob, 8, 8, gpuResourceName)
+	expWorker := newWorker(mpiJob, 8, 8, gpuResourceName, false)
 	f.expectCreateStatefulSetAction(expWorker)
 
 	mpiJobCopy := mpiJob.DeepCopy()
@@ -583,7 +584,7 @@ func TestLauncherDoesNotExistWithCustomResources(t *testing.T) {
 		expRoleBinding := newLauncherRoleBinding(mpiJob)
 		f.expectCreateRoleBindingAction(expRoleBinding)
 
-		expWorker := newWorker(mpiJob, 4, 4, resourceName)
+		expWorker := newWorker(mpiJob, 4, 4, resourceName, false)
 		f.expectCreateStatefulSetAction(expWorker)
 
 		mpiJobCopy := mpiJob.DeepCopy()
@@ -676,10 +677,10 @@ func TestShutdownWorker(t *testing.T) {
 	launcher.Status.Succeeded = 1
 	f.setUpLauncher(launcher)
 
-	worker := newWorker(mpiJob, 8, 8, gpuResourceName)
+	worker := newWorker(mpiJob, 8, 8, gpuResourceName, false)
 	f.setUpWorker(worker)
 
-	expWorker := newWorker(mpiJob, 0, 8, gpuResourceName)
+	expWorker := newWorker(mpiJob, 0, 8, gpuResourceName, false)
 	f.expectUpdateStatefulSetAction(expWorker)
 
 	mpiJobCopy := mpiJob.DeepCopy()
@@ -702,7 +703,7 @@ func TestWorkerNotControlledByUs(t *testing.T) {
 	f.setUpConfigMap(newConfigMap(mpiJob, 8, 8))
 	f.setUpRbac(mpiJob, 8)
 
-	worker := newWorker(mpiJob, 8, 8, gpuResourceName)
+	worker := newWorker(mpiJob, 8, 8, gpuResourceName, false)
 	worker.OwnerReferences = nil
 	f.setUpWorker(worker)
 
@@ -725,7 +726,7 @@ func TestLauncherActive(t *testing.T) {
 	launcher.Status.Active = 1
 	f.setUpLauncher(launcher)
 
-	worker := newWorker(mpiJob, 1, 8, gpuResourceName)
+	worker := newWorker(mpiJob, 1, 8, gpuResourceName, false)
 	f.setUpWorker(worker)
 
 	mpiJobCopy := mpiJob.DeepCopy()
@@ -747,7 +748,7 @@ func TestWorkerReady(t *testing.T) {
 	f.setUpConfigMap(newConfigMap(mpiJob, 2, 8))
 	f.setUpRbac(mpiJob, 2)
 
-	worker := newWorker(mpiJob, 2, 8, gpuResourceName)
+	worker := newWorker(mpiJob, 2, 8, gpuResourceName, false)
 	worker.Status.ReadyReplicas = 2
 	f.setUpWorker(worker)
 
@@ -773,7 +774,7 @@ func TestWorkerReadyWithCPUs(t *testing.T) {
 	f.setUpConfigMap(newConfigMap(mpiJob, 2, 8))
 	f.setUpRbac(mpiJob, 2)
 
-	worker := newWorker(mpiJob, 2, 8, cpuResourceName)
+	worker := newWorker(mpiJob, 2, 8, cpuResourceName, false)
 	worker.Status.ReadyReplicas = 2
 	f.setUpWorker(worker)
 
@@ -786,6 +787,21 @@ func TestWorkerReadyWithCPUs(t *testing.T) {
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
 	f.run(getKey(mpiJob, t), cpuResourceName)
+}
+
+func TestEnableGangScheduling(t *testing.T) {
+	f := newFixture(t)
+	startTime := metav1.Now()
+	completionTime := metav1.Now()
+
+	mpiJob := newMPIJobWithCPUs("test", int32Ptr(16), &startTime, &completionTime)
+	f.setUpMPIJob(mpiJob)
+
+	f.setUpConfigMap(newConfigMap(mpiJob, 2, 8))
+	f.setUpRbac(mpiJob, 2)
+
+	worker := newWorker(mpiJob, 2, 8, cpuResourceName, true)
+	assert.Equal(t, gangSchedulerName, worker.Spec.Template.Spec.SchedulerName)
 }
 
 func int32Ptr(i int32) *int32 { return &i }


### PR DESCRIPTION
 Use kube-batch as scheduler by default when gang-scheduling is enabled, if scheduler is set, log warning message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/100)
<!-- Reviewable:end -->
