### PR TITLE
Fix some lint errors

### DIFF
--- a/pkg/apis/kubeflow/v1alpha2/common_types.go
+++ b/pkg/apis/kubeflow/v1alpha2/common_types.go
@@ -129,6 +129,7 @@ const (
 // CleanPodPolicy describes how to deal with pods when the job is finished.
 type CleanPodPolicy string
 
+// Possible values for CleanPodPolicy
 const (
 	CleanPodPolicyUndefined CleanPodPolicy = ""
 	CleanPodPolicyAll       CleanPodPolicy = "All"
@@ -142,12 +143,13 @@ const (
 // is RestartPolicyAlways.
 type RestartPolicy string
 
+// Possible values for RestartPolicy 
 const (
 	RestartPolicyAlways    RestartPolicy = "Always"
 	RestartPolicyOnFailure RestartPolicy = "OnFailure"
 	RestartPolicyNever     RestartPolicy = "Never"
 
-	// `ExitCode` policy means that user should add exit code by themselves,
+	// RestartPolicyExitCode policy means that user should add exit code by themselves,
 	// The job operator will check these exit codes to
 	// determine the behavior when an error occurs:
 	// - 1-127: permanent error, do not restart.


### PR DESCRIPTION
Per https://goreportcard.com/report/github.com/kubeflow/mpi-operator#golint, most of lint errors are due to boilerplate code generated by kubebuilder. Here I fixed errors that are not. 

Test:
ran `golint` locally and verified the errors I intended to fix disappeared

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/107)
<!-- Reviewable:end -->
