### PR TITLE
Switch pdb to podgroup for gang scheduling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,6 +163,28 @@
   revision = "4a52f2af73739a5708067cec347be435aca3924e"
 
 [[projects]]
+  branch = "master"
+  digest = "1:7f9597e4420870f6704a35709f2d6414d003c11821e0b42f8fe2815a1f3ac18c"
+  name = "github.com/kubernetes-sigs/kube-batch"
+  packages = [
+    "pkg/apis/scheduling/v1alpha1",
+    "pkg/apis/scheduling/v1alpha2",
+    "pkg/client/clientset/versioned",
+    "pkg/client/clientset/versioned/scheme",
+    "pkg/client/clientset/versioned/typed/scheduling/v1alpha1",
+    "pkg/client/clientset/versioned/typed/scheduling/v1alpha2",
+    "pkg/client/informers/externalversions",
+    "pkg/client/informers/externalversions/internalinterfaces",
+    "pkg/client/informers/externalversions/scheduling",
+    "pkg/client/informers/externalversions/scheduling/v1alpha1",
+    "pkg/client/informers/externalversions/scheduling/v1alpha2",
+    "pkg/client/listers/scheduling/v1alpha1",
+    "pkg/client/listers/scheduling/v1alpha2",
+  ]
+  pruneopts = ""
+  revision = "c8a02d1e51b24d65b71d324bbf9d7e58e0b0f17e"
+
+[[projects]]
   digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -718,6 +740,11 @@
     "github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha1",
     "github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2",
     "github.com/kubeflow/mpi-operator/pkg/version",
+    "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha2",
+    "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned",
+    "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions",
+    "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha2",
+    "github.com/kubernetes-sigs/kube-batch/pkg/client/listers/scheduling/v1alpha2",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",

--- a/cmd/mpi-operator.v1alpha2/app/server.go
+++ b/cmd/mpi-operator.v1alpha2/app/server.go
@@ -21,12 +21,14 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	controllersv1alpha2 "github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2"
+	kubebatchclient "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
+	kubebatchinformers "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions"
+	podgroupsinformer "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeinformers "k8s.io/client-go/informers"
-	policyinformers "k8s.io/client-go/informers/policy/v1beta1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	clientgokubescheme "k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -41,8 +43,8 @@ import (
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v1alpha2"
 	mpijobclientset "github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned"
 	informers "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions"
+	controllersv1alpha2 "github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2"
 	"github.com/kubeflow/mpi-operator/pkg/version"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -94,7 +96,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	// Create clients.
-	kubeClient, leaderElectionClientSet, mpiJobClientSet, err := createClientSets(cfg)
+	kubeClient, leaderElectionClientSet, mpiJobClientSet, kubeBatchClientSet, err := createClientSets(cfg)
 	if err != nil {
 		return err
 	}
@@ -107,28 +109,32 @@ func Run(opt *options.ServerOption) error {
 	run := func(ctx context.Context) {
 		var kubeInformerFactory kubeinformers.SharedInformerFactory
 		var kubeflowInformerFactory informers.SharedInformerFactory
+		var kubebatchInformerFactory kubebatchinformers.SharedInformerFactory
 		if opt.Namespace == "" {
 			kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 			kubeflowInformerFactory = informers.NewSharedInformerFactory(mpiJobClientSet, 0)
+			kubebatchInformerFactory = kubebatchinformers.NewSharedInformerFactory(kubeBatchClientSet, 0)
 		} else {
 			kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(opt.Namespace), nil)
 			kubeflowInformerFactory = informers.NewSharedInformerFactoryWithOptions(mpiJobClientSet, 0, informers.WithNamespace(opt.Namespace), nil)
+			kubebatchInformerFactory = kubebatchinformers.NewSharedInformerFactoryWithOptions(kubeBatchClientSet, 0, kubebatchinformers.WithNamespace(opt.Namespace), nil)
 		}
 
-		var pdbInformer policyinformers.PodDisruptionBudgetInformer
+		var podgroupsInformer podgroupsinformer.PodGroupInformer
 		if opt.EnableGangScheduling {
-			pdbInformer = kubeInformerFactory.Policy().V1beta1().PodDisruptionBudgets()
+			podgroupsInformer = kubebatchInformerFactory.Scheduling().V1alpha2().PodGroups()
 		}
 		controller := controllersv1alpha2.NewMPIJobController(
 			kubeClient,
 			mpiJobClientSet,
+			kubeBatchClientSet,
 			kubeInformerFactory.Core().V1().ConfigMaps(),
 			kubeInformerFactory.Core().V1().ServiceAccounts(),
 			kubeInformerFactory.Rbac().V1().Roles(),
 			kubeInformerFactory.Rbac().V1().RoleBindings(),
 			kubeInformerFactory.Apps().V1().StatefulSets(),
 			kubeInformerFactory.Batch().V1().Jobs(),
-			pdbInformer,
+			podgroupsInformer,
 			kubeflowInformerFactory.Kubeflow().V1alpha2().MPIJobs(),
 			opt.KubectlDeliveryImage,
 			opt.EnableGangScheduling)
@@ -195,24 +201,29 @@ func Run(opt *options.ServerOption) error {
 	return fmt.Errorf("finished without leader elect")
 }
 
-func createClientSets(config *restclientset.Config) (kubeclientset.Interface, kubeclientset.Interface, mpijobclientset.Interface, error) {
+func createClientSets(config *restclientset.Config) (kubeclientset.Interface, kubeclientset.Interface, mpijobclientset.Interface, kubebatchclient.Interface, error) {
 
 	kubeClientSet, err := kubeclientset.NewForConfig(restclientset.AddUserAgent(config, "mpi-operator"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	leaderElectionClientSet, err := kubeclientset.NewForConfig(restclientset.AddUserAgent(config, "leader-election"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	mpiJobClientSet, err := mpijobclientset.NewForConfig(config)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return kubeClientSet, leaderElectionClientSet, mpiJobClientSet, nil
+	kubeBatchClientSet, err := kubebatchclient.NewForConfig(restclientset.AddUserAgent(config, "kube-batch"))
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	return kubeClientSet, leaderElectionClientSet, mpiJobClientSet, kubeBatchClientSet, nil
 }
 
 func checkCRDExists(clientset mpijobclientset.Interface, namespace string) bool {


### PR DESCRIPTION
Pdb has been deprecated in kube-batch.

 <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/111)
<!-- Reviewable:end -->
