### PR TITLE
Change the launcher done status judge logic

### DIFF
--- a/pkg/controllers/v1alpha1/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha1/mpi_job_controller.go
@@ -458,7 +458,7 @@ func (c *MPIJobController) syncHandler(key string) error {
 		return err
 	}
 	// We're done if the launcher either succeeded or failed.
-	done := launcher != nil && (launcher.Status.Succeeded == 1 || launcher.Status.Failed == 1)
+	done := launcher != nil && IsJobFinished(launcher)
 
 	// TODO (terrytangyuan): Remove these flags from main.go for next major release
 	// and update deploy/*.yaml
@@ -1260,4 +1260,13 @@ func getLabelsMap(mpiJob *kubeflow.MPIJob) map[string]string {
 
 func getLauncherName(mpiJob *kubeflow.MPIJob) string {
 	return mpiJob.Name + launcherSuffix
+}
+
+func IsJobFinished(launcher *batchv1.Job) bool {
+    for _, c := range launcher.Status.Conditions {
+        if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
+            return true
+        }
+    }
+    return false
 }

--- a/pkg/controllers/v1alpha1/mpi_job_controller_test.go
+++ b/pkg/controllers/v1alpha1/mpi_job_controller_test.go
@@ -512,6 +512,7 @@ func TestLauncherSucceededWithGang(t *testing.T) {
 
 	launcher := newLauncher(mpiJob, "kubectl-delivery")
 	launcher.Status.Succeeded = 1
+	launcher.Status.Conditions = []batchv1.JobCondition{batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 	f.setUpLauncher(launcher)
 
 	mpiJobCopy := mpiJob.DeepCopy()
@@ -532,6 +533,7 @@ func TestLauncherSucceeded(t *testing.T) {
 
 	launcher := newLauncher(mpiJob, "kubectl-delivery")
 	launcher.Status.Succeeded = 1
+	launcher.Status.Conditions = []batchv1.JobCondition{batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 	f.setUpLauncher(launcher)
 
 	mpiJobCopy := mpiJob.DeepCopy()
@@ -549,12 +551,12 @@ func TestLauncherFailed(t *testing.T) {
 	mpiJob := newMPIJob("test", int32Ptr(64), &startTime, nil)
 	f.setUpMPIJob(mpiJob)
 
+	mpiJob.Status.LauncherStatus = kubeflow.LauncherFailed
 	launcher := newLauncher(mpiJob, "kubectl-delivery")
-	launcher.Status.Failed = 1
+	launcher.Status.Conditions = []batchv1.JobCondition{batchv1.JobCondition{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
 	f.setUpLauncher(launcher)
 
 	mpiJobCopy := mpiJob.DeepCopy()
-	mpiJobCopy.Status.LauncherStatus = kubeflow.LauncherFailed
 	setUpMPIJobTimestamp(mpiJobCopy, &startTime, nil)
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
@@ -705,6 +707,7 @@ func TestShutdownWorker(t *testing.T) {
 
 	launcher := newLauncher(mpiJob, "kubectl-delivery")
 	launcher.Status.Succeeded = 1
+	launcher.Status.Conditions = []batchv1.JobCondition{batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 	f.setUpLauncher(launcher)
 
 	worker := newWorker(mpiJob, 8, 8, gpuResourceName, false)


### PR DESCRIPTION
I think the launcher done status judge logic description `launcher.Status.Failed == 1`, because of `job.Status.Failed`   is the num of failed pod, and when i test, it may get nums < backoffLimit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/113)
<!-- Reviewable:end -->
