### PR TITLE
add subresources status to crd

### DIFF
--- a/deploy/crd/crd-v1alpha2.yaml
+++ b/deploy/crd/crd-v1alpha2.yaml
@@ -13,6 +13,8 @@ spec:
     shortNames:
     - mj
     - mpij
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Since we use `updateStatus` to update mpijob status, we need add subresources status to crd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/117)
<!-- Reviewable:end -->
