### PR TITLE
add job priority for kube-batch

### DIFF
--- a/deploy/crd/crd-v1alpha2.yaml
+++ b/deploy/crd/crd-v1alpha2.yaml
@@ -23,6 +23,8 @@ spec:
             slotsPerWorker:
               type: integer
               minimum: 1
+            jobPriority:
+              type: string
             mpiReplicaSpecs:
               properties:
                 Launcher:

--- a/pkg/apis/kubeflow/v1alpha1/types.go
+++ b/pkg/apis/kubeflow/v1alpha1/types.go
@@ -71,6 +71,11 @@ type MPIJobSpec struct {
 	// +optional
 	SlotsPerWorker *int32 `json:"slotsPerWorker,omitempty"`
 
+	// Specifies the priority of the job.
+	// Defaults to 0.
+	// +optional
+	JobPriority *string `json:"jobPriority,omitempty"`
+
 	// Run the launcher on the master.
 	// Defaults to false.
 	// +optional

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -44,6 +44,11 @@ type MPIJobSpec struct {
 	// +optional
 	SlotsPerWorker *int32 `json:"slotsPerWorker,omitempty"`
 
+	// Specifies the priority of the job.
+	// Defaults to 0.
+	// +optional
+	JobPriority *string `json:"jobPriority,omitempty"`
+
 	// TODO: Move this to `RunPolicy` in common operator, see discussion in https://github.com/kubeflow/tf-operator/issues/960
 	// Specifies the number of retries before marking this job failed.
 	// Defaults to 6.

--- a/pkg/apis/kubeflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeflow/v1alpha2/zz_generated.deepcopy.go
@@ -92,6 +92,11 @@ func (in *MPIJobSpec) DeepCopyInto(out *MPIJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.JobPriority != nil {
+		in, out := &in.JobPriority, &out.JobPriority
+		*out = new(string)
+		**out = **in
+	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
 		*out = new(int32)

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1046,6 +1046,7 @@ func newPodGroup(mpiJob *kubeflow.MPIJob, minAvailableReplicas int32) *podgroupv
 		},
 		Spec: podgroupv1alpha1.PodGroupSpec{
 			MinMember: minAvailableReplicas,
+			PriorityClassName: *mpiJob.Spec.JobPriority,
 		},
 	}
 }


### PR DESCRIPTION
Add job priority for kube-batch scheduling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/140)
<!-- Reviewable:end -->
