### PR TITLE
update status to running only when both launcher and workers are ready

### DIFF
--- a/pkg/controllers/v1alpha2/mpi_job_controller_status.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller_status.go
@@ -15,7 +15,7 @@
 package v1alpha2
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	common "github.com/kubeflow/common/job_controller/api/v1"

--- a/pkg/controllers/v1alpha2/mpi_job_controller_test.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller_test.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
After PR #132 , launcher batch Job will have `Status.Active > 0` even when worker pods are not ready. This is going to show a misleading status of JobRunning.
This error happens when, e.g., pod creation in the worker StatefulSet failed because of exceeding Resource Quota. 

This PR modifies the update status logic to check both launcher and worker status for entering JobRunning condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/145)
<!-- Reviewable:end -->
