### PR TITLE
update status to running only when both launcher and workers are ready

### DIFF
--- a/pkg/controllers/v1alpha2/mpi_job_controller_status.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller_status.go
@@ -15,7 +15,7 @@
 package v1alpha2
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	common "github.com/kubeflow/common/job_controller/api/v1"

--- a/pkg/controllers/v1alpha2/mpi_job_controller_test.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller_test.go
@@ -737,7 +737,45 @@ func TestWorkerNotControlledByUs(t *testing.T) {
 	f.runExpectError(getKey(mpiJob, t))
 }
 
-func TestLauncherActive(t *testing.T) {
+func TestLauncherActiveWorkerNotReady(t *testing.T) {
+	f := newFixture(t)
+	startTime := metav1.Now()
+	completionTime := metav1.Now()
+
+	mpiJob := newMPIJob("test", int32Ptr(8), 1, gpuResourceName, &startTime, &completionTime)
+	f.setUpMPIJob(mpiJob)
+
+	f.setUpConfigMap(newConfigMap(mpiJob, 1))
+	f.setUpRbac(mpiJob, 1)
+
+	fmjc := newFakeMPIJobController()
+	launcher := fmjc.newLauncher(mpiJob, "kubectl-delivery")
+	launcher.Status.Active = 1
+	f.setUpLauncher(launcher)
+
+	worker := newWorker(mpiJob, 8, false)
+	worker.Status.ReadyReplicas = 0
+	f.setUpWorker(worker)
+	mpiJobCopy := mpiJob.DeepCopy()
+	mpiJobCopy.Status.ReplicaStatuses = map[common.ReplicaType]*common.ReplicaStatus{
+		common.ReplicaType(kubeflow.MPIReplicaTypeLauncher): {
+			Active:    1,
+			Succeeded: 0,
+			Failed:    0,
+		},
+		common.ReplicaType(kubeflow.MPIReplicaTypeWorker): {
+			Active:    0,
+			Succeeded: 0,
+			Failed:    0,
+		},
+	}
+	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
+	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
+
+	f.run(getKey(mpiJob, t))
+}
+
+func TestLauncherActiveWorkerReady(t *testing.T) {
 	f := newFixture(t)
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
@@ -755,6 +793,7 @@ func TestLauncherActive(t *testing.T) {
 
 	worker := newWorker(mpiJob, 8, false)
 	f.setUpWorker(worker)
+	worker.Status.ReadyReplicas = 8
 	mpiJobCopy := mpiJob.DeepCopy()
 	mpiJobCopy.Status.ReplicaStatuses = map[common.ReplicaType]*common.ReplicaStatus{
 		common.ReplicaType(kubeflow.MPIReplicaTypeLauncher): {
@@ -763,7 +802,7 @@ func TestLauncherActive(t *testing.T) {
 			Failed:    0,
 		},
 		common.ReplicaType(kubeflow.MPIReplicaTypeWorker): {
-			Active:    0,
+			Active:    8,
 			Succeeded: 0,
 			Failed:    0,
 		},


### PR DESCRIPTION
After PR #132 , launcher batch Job will have Status.Active > 0 even when worker pods are not ready. This is going to show a misleading status of JobRunning.
This error happens when, e.g., pod creation in the worker StatefulSet failed because of exceeding Resource Quota.

This PR modifies the update status logic to check both launcher and worker status for entering JobRunning condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/146)
<!-- Reviewable:end -->
