### PR TITLE
ocp4_x

### DIFF
--- a/deploy/mpi-operator.yaml
+++ b/deploy/mpi-operator.yaml
@@ -141,6 +141,7 @@ rules:
   - kubeflow.org
   resources:
   - mpijobs
+  - mpijobs/finalizers
   - mpijobs/status
   verbs:
   - "*"


### PR DESCRIPTION
Added support for RH OCP4.1 and RH OCP4.2. See discussion in https://github.com/kubeflow/mpi-operator/issues/151.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/153)
<!-- Reviewable:end -->
