### PR TITLE
Honor user-typed worker command

### DIFF
--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -64,6 +64,11 @@ type MPIJobSpec struct {
 	// `MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that
 	// specify the MPI replicas to run.
 	MPIReplicaSpecs map[MPIReplicaType]*common.ReplicaSpec `json:"mpiReplicaSpecs"`
+
+	// Describes worker commands. Workers run this command when get started.
+	// Defaults to "sleep 365d"
+	// +optional
+	WorkerCommand string `json:"workerCommand,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -64,11 +64,6 @@ type MPIJobSpec struct {
 	// `MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that
 	// specify the MPI replicas to run.
 	MPIReplicaSpecs map[MPIReplicaType]*common.ReplicaSpec `json:"mpiReplicaSpecs"`
-
-	// Describes worker commands. Workers run this command when get started.
-	// Defaults to "sleep 365d"
-	// +optional
-	WorkerCommand string `json:"workerCommand,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1080,8 +1080,13 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, enableGangSchedul
 	podSpec.Spec.RestartPolicy = corev1.RestartPolicyAlways
 
 	container := podSpec.Spec.Containers[0]
-	container.Command = []string{"sleep"}
-	container.Args = []string{"365d"}
+	if len(mpiJob.Spec.WorkerCommand) > 0 {
+		container.Command = []string{"/bin/bash", "-c", mpiJob.Spec.WorkerCommand}
+		container.Args = []string{}
+	} else {
+		container.Command = []string{"sleep"}
+		container.Args = []string{"365d"}
+	}
 
 	// We need the kubexec.sh script here because Open MPI checks for the path
 	// in every rank.

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1080,10 +1080,7 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, enableGangSchedul
 	podSpec.Spec.RestartPolicy = corev1.RestartPolicyAlways
 
 	container := podSpec.Spec.Containers[0]
-	if len(mpiJob.Spec.WorkerCommand) > 0 {
-		container.Command = []string{"/bin/bash", "-c", mpiJob.Spec.WorkerCommand}
-		container.Args = []string{}
-	} else {
+	if len(container.Command) == 0 {
 		container.Command = []string{"sleep"}
 		container.Args = []string{"365d"}
 	}


### PR DESCRIPTION
The worker command was hardcoded as `sleep 365d`, no matter what command users specify. This PR is to honor users' inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/175)
<!-- Reviewable:end -->
