### PR TITLE
Add error log when pod spec does not have any containers

### DIFF
--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1080,6 +1080,9 @@ func newWorker(mpiJob *kubeflow.MPIJob, desiredReplicas int32, gangSchedulerName
 	// always set restartPolicy to restartAlways for statefulset
 	podSpec.Spec.RestartPolicy = corev1.RestartPolicyAlways
 
+	if len(podSpec.Spec.Containers) == 0 {
+		glog.Errorln("Worker pod does not have any containers in its spec")
+	}
 	container := podSpec.Spec.Containers[0]
 	if len(container.Command) == 0 {
 		container.Command = []string{"sleep"}
@@ -1214,6 +1217,9 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 			},
 		},
 	})
+	if len(podSpec.Spec.Containers) == 0 {
+		glog.Errorln("Launcher pod does not have any containers in its spec")
+	}
 	container := podSpec.Spec.Containers[0]
 	container.Env = append(container.Env,
 		corev1.EnvVar{


### PR DESCRIPTION
Sometimes if MPIJob spec has certain field in the wrong indentation, `kubectl apply` still passes the validation check. However, the controller will crash with panic in such cases. 

For example, if there are no containers specified in the pod specs, the controller will crash. We may need a better error propagation mechanism but for now it's good to print out the error message in this case. Otherwise it's hard for users to debug.

Example panic log (truncated):
```
I0212 15:10:57.092103       1 mpi_job_controller.go:352] Starting workers
I0212 15:10:57.092145       1 mpi_job_controller.go:358] Started workers
I0212 15:10:57.092327       1 mpi_job_controller.go:433] Finished syncing job "kubemaker/tensorflow-benchmarks" (148.32µs)
E0212 15:10:57.092452       1 runtime.go:69] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:76
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:65
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:679
/usr/local/go/src/runtime/panic.go:75
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:1086
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:740
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:535
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:408
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:417
/go/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2/mpi_job_controller.go:369
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:133
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:134
/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1357
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 218 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:58 +0x105
panic(0x136c020, 0xc000b87aa0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/kubeflow/mpi-operator/pkg/controllers/v1alpha2.newWorker(0xc0004e0480, 0x1, 0x9)
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/190)
<!-- Reviewable:end -->
