### PR TITLE
fix namespace issue

### DIFF
--- a/cmd/mpi-operator.v1alpha2/app/options/options.go
+++ b/cmd/mpi-operator.v1alpha2/app/options/options.go
@@ -16,8 +16,9 @@ package options
 
 import (
 	"flag"
+	"os"
 
-	v1 "k8s.io/api/core/v1"
+	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v1alpha2"
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -29,6 +30,7 @@ type ServerOption struct {
 	PrintVersion         bool
 	GangSchedulingName   string
 	Namespace            string
+	LockNamespace        string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -49,7 +51,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.KubectlDeliveryImage, "kubectl-delivery-image", "",
 		"The container image used to deliver the kubectl binary.")
 
-	fs.StringVar(&s.Namespace, "namespace", v1.NamespaceAll,
+	fs.StringVar(&s.Namespace, "namespace", os.Getenv(v1alpha2.EnvKubeflowNamespace),
 		`The namespace to monitor mpijobs. If unset, it monitors all namespaces cluster-wide. 
                 If set, it only monitors mpijobs in the given namespace.`)
 
@@ -59,4 +61,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 
 	fs.StringVar(&s.GangSchedulingName, "gang-scheduling", "", "Set gang scheduler name if enable gang scheduling.")
+
+	fs.StringVar(&s.LockNamespace, "lock-namespace", "mpi-operator", "Set locked namespace name while enabling leader election.")
 }


### PR DESCRIPTION
fix https://github.com/kubeflow/mpi-operator/issues/198

```
$ ./mpi-operator.v1alpha2 --help
Usage of ./mpi-operator.v1alpha2:
  -alsologtostderr
    	log to standard error as well as files
  -gang-scheduling string
    	Set gang scheduler name if enable gang scheduling.
  -kubeConfig string
    	Path to a kubeConfig. Only required if out-of-cluster.
  -kubectl-delivery-image string
    	The container image used to deliver the kubectl binary.
  -lock-namespace string
    	Set locked namespace name while enabling leader election. (default "mpi-operator")
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -master string
    	The url of the Kubernetes API server,
    			 will overrides any value in kubeconfig, only required if out-of-cluster.
  -namespace string
    	The namespace to monitor mpijobs. If unset, it monitors all namespaces cluster-wide.
    	                If set, it only monitors mpijobs in the given namespace.
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -threadiness int
    	How many threads to process the main logic (default 2)
  -v value
    	log level for V logs
  -version
    	Show version and quit
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/mpi-operator/205)
<!-- Reviewable:end -->
