### PR TITLE
add monitor metrics

### DIFF
--- a/cmd/mpi-operator.v1alpha2/app/options/options.go
+++ b/cmd/mpi-operator.v1alpha2/app/options/options.go
@@ -27,6 +27,7 @@ type ServerOption struct {
 	MasterURL            string
 	KubectlDeliveryImage string
 	Threadiness          int
+	MonitoringPort       int
 	PrintVersion         bool
 	GangSchedulingName   string
 	Namespace            string
@@ -59,6 +60,9 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 		`How many threads to process the main logic`)
 
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
+
+	fs.IntVar(&s.MonitoringPort, "monitoring-port", 8443,
+		`Endpoint port for displaying monitoring metrics. It can be set to "0" to disable the metrics serving.`)
 
 	fs.StringVar(&s.GangSchedulingName, "gang-scheduling", "", "Set gang scheduler name if enable gang scheduling.")
 

--- a/cmd/mpi-operator.v1alpha2/app/options/options.go
+++ b/cmd/mpi-operator.v1alpha2/app/options/options.go
@@ -61,7 +61,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 
-	fs.IntVar(&s.MonitoringPort, "monitoring-port", 8443,
+	fs.IntVar(&s.MonitoringPort, "monitoring-port", 0,
 		`Endpoint port for displaying monitoring metrics. It can be set to "0" to disable the metrics serving.`)
 
 	fs.StringVar(&s.GangSchedulingName, "gang-scheduling", "", "Set gang scheduler name if enable gang scheduling.")

--- a/cmd/mpi-operator.v1alpha2/app/server.go
+++ b/cmd/mpi-operator.v1alpha2/app/server.go
@@ -17,8 +17,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"net/http"
 	"os"
 	"time"
@@ -28,6 +26,8 @@ import (
 	kubebatchclient "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
 	kubebatchinformers "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions"
 	podgroupsinformer "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/mpi-operator.v1alpha2/main.go
+++ b/cmd/mpi-operator.v1alpha2/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"strconv"
 
@@ -25,6 +24,7 @@ import (
 
 	"github.com/kubeflow/mpi-operator/cmd/mpi-operator.v1alpha2/app"
 	"github.com/kubeflow/mpi-operator/cmd/mpi-operator.v1alpha2/app/options"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func startMonitoring(monitoringPort int) {

--- a/cmd/mpi-operator.v1alpha2/main.go
+++ b/cmd/mpi-operator.v1alpha2/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/golang/glog"
 
@@ -30,9 +29,9 @@ import (
 func startMonitoring(monitoringPort int) {
 	if monitoringPort != 0 {
 		go func() {
-			glog.Infof("Setting up client for monitoring on port: %s", strconv.Itoa(monitoringPort))
+			glog.Infof("Setting up client for monitoring on port: %d", monitoringPort)
 			http.Handle("/metrics", promhttp.Handler())
-			err := http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(monitoringPort)), nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", monitoringPort), nil)
 			if err != nil {
 				glog.Error("Monitoring endpoint setup failure.", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/kubeflow/common v0.0.0-20200313171840-64f943084a05
 	github.com/kubernetes-sigs/kube-batch v0.5.0
 	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	github.com/prometheus/client_golang v0.9.2
 	github.com/stretchr/testify v1.3.0
 	k8s.io/api v0.15.10
 	k8s.io/apimachinery v0.15.10

--- a/go.sum
+++ b/go.sum
@@ -315,13 +315,16 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJDADN2ufcGik7W992pyps0wZ888b/y9GXcLTU=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.1.0 h1:IxU7wGikQPAcoOd3/f4Ol7+vIKS1Sgu08tzjktR4nJE=
 github.com/prometheus/common v0.1.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -17,8 +17,6 @@ package v1alpha2
 import (
 	"bytes"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"reflect"
 	"time"
 
@@ -29,6 +27,8 @@ import (
 	kubebatchclient "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
 	podgroupsinformer "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	podgroupslists "github.com/kubernetes-sigs/kube-batch/pkg/client/listers/scheduling/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Fully based on [tf-operator](https://github.com/kubeflow/tf-operator/pull/1018), add the metrics monitor by Prometheus in mpi-operator, which can report the Mpijob metrics like creation, deletion, completion and failure.