### PR TITLE
Add defaults for backOffLimit and activeDeadlineSeconds

### DIFF
--- a/pkg/controllers/v1/mpi_job_controller.go
+++ b/pkg/controllers/v1/mpi_job_controller.go
@@ -1328,7 +1328,6 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 	backOffLimit := new(int32)
 	*backOffLimit = 6
 	var activeDeadlineSeconds *int64
-	activeDeadlineSeconds = nil
 	if mpiJob.Spec.RunPolicy != nil {
 		if mpiJob.Spec.RunPolicy.BackoffLimit != nil {
 			backOffLimit = mpiJob.Spec.RunPolicy.BackoffLimit

--- a/pkg/controllers/v1/mpi_job_controller.go
+++ b/pkg/controllers/v1/mpi_job_controller.go
@@ -1327,7 +1327,7 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 	
 	backOffLimit := new(int32)
 	*backOffLimit = 6
-	activeDeadlineSeconds := new(int64)
+	var activeDeadlineSeconds *int64
 	activeDeadlineSeconds = nil
 	if mpiJob.Spec.RunPolicy != nil {
 		if mpiJob.Spec.RunPolicy.BackoffLimit != nil {

--- a/pkg/controllers/v1/mpi_job_controller.go
+++ b/pkg/controllers/v1/mpi_job_controller.go
@@ -1324,6 +1324,19 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 				},
 			},
 		})
+	
+	backOffLimit := new(int32)
+	*backOffLimit = 6
+	activeDeadlineSeconds := new(int64)
+	activeDeadlineSeconds = nil
+	if mpiJob.Spec.RunPolicy != nil {
+		if mpiJob.Spec.RunPolicy.BackoffLimit != nil {
+			backOffLimit = mpiJob.Spec.RunPolicy.BackoffLimit
+		}
+		if mpiJob.Spec.RunPolicy.ActiveDeadlineSeconds != nil {
+			activeDeadlineSeconds = mpiJob.Spec.RunPolicy.ActiveDeadlineSeconds
+		}
+	}
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      launcherName,
@@ -1334,8 +1347,8 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit:          mpiJob.Spec.RunPolicy.BackoffLimit,
-			ActiveDeadlineSeconds: mpiJob.Spec.RunPolicy.ActiveDeadlineSeconds,
+			BackoffLimit:          backOffLimit,
+			ActiveDeadlineSeconds: activeDeadlineSeconds,
 			Template:              *podSpec,
 		},
 	}


### PR DESCRIPTION
Somehow Travis build was not triggered in https://github.com/kubeflow/mpi-operator/pull/221 so the following failure was not detected before merging. This PR fixes the CI failure:
```
--- FAIL: TestLauncherNotControlledByUs (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1d34a93]

goroutine 140 [running]:
testing.tRunner.func1(0xc000228100)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:874 +0x3a3
panic(0x1e76ac0, 0x2b1df90)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/kubeflow/mpi-operator/pkg/controllers/v1.(*MPIJobController).newLauncher(0xc000591ce8, 0xc0001a2b60, 0x200855b, 0x10, 0x1)
	/Users/yuan.tang/go-workspace/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1/mpi_job_controller.go:1337 +0x12e3
github.com/kubeflow/mpi-operator/pkg/controllers/v1.TestLauncherNotControlledByUs(0xc000228100)
	/Users/yuan.tang/go-workspace/src/github.com/kubeflow/mpi-operator/pkg/controllers/v1/mpi_job_controller_test.go:508 +0x2e3
testing.tRunner(0xc000228100, 0x2090230)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:960 +0x350
FAIL	github.com/kubeflow/mpi-operator/pkg/controllers/v1	0.438s
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>