### PR TITLE
Fix issue in v1 controller's CRD existence check

### DIFF
--- a/cmd/mpi-operator.v1/app/server.go
+++ b/cmd/mpi-operator.v1/app/server.go
@@ -285,7 +285,7 @@ func createClientSets(config *restclientset.Config) (kubeclientset.Interface, ku
 }
 
 func checkCRDExists(clientset mpijobclientset.Interface, namespace string) bool {
-	_, err := clientset.KubeflowV1alpha2().MPIJobs(namespace).List(metav1.ListOptions{})
+	_, err := clientset.KubeflowV1().MPIJobs(namespace).List(metav1.ListOptions{})
 
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
Fixes the issue `the server could not find the requested resource (get mpijobs.kubeflow.org)`. This should be looking for v1 MPIJob instead of v1alpha2. See discussion in https://github.com/kubeflow/katib/pull/1183#discussion_r424989687.