### PR TITLE
Add nodeSelector and tolerations in Helm Charts

### DIFF
--- a/hack/helm/mpi-operator/templates/mpi-operator-deployment.yaml
+++ b/hack/helm/mpi-operator/templates/mpi-operator-deployment.yaml
@@ -43,3 +43,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}

--- a/hack/helm/mpi-operator/values.yaml
+++ b/hack/helm/mpi-operator/values.yaml
@@ -34,3 +34,20 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for the sparkoperator deployment
+##
+## Example:
+##   - key: "toleration=key"
+##     operator: "Equal"
+##     value: "value"
+##     effect: "NoSchedule"
+##
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []


### PR DESCRIPTION
I think it would be better if we could set the `nodeSelector` and `tolerations` while installing the mpi-operator :)