### PR TITLE
Prune OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,7 @@
 approvers:
-  - anfeng
-    # jlewi@ is just a backup in case other approvers aren't available.  
-  - jlewi
-  - madhukarkm
   - rongou
   - terrytangyuan
 reviewers:
-  - cheyang
   - everpeace
   - gaocegege
-  - nivedita-v
-  - fisherxu
   - carmark


### PR DESCRIPTION
From @jlewi 

> A couple of things to call out for people who have been discussing forming WGs in various areas.
>
>* Please take a look at the roles defined for each WG and think about who you would want to assume those roles
>
>* Please think about ensuring your OWNERs files are up to date and adequately reflect who the OWNERs are for various sub projects. This will be critical to ensuring OWNERs don't get overlooked.

This PR removes inactive reviewers/approvers. If there's any objection on any of the removed people, feel free to comment.