### PR TITLE
add support for using Intel MPI(2019.7) and MVAPICH2

### DIFF
--- a/cmd/kubectl-delivery/app/server.go
+++ b/cmd/kubectl-delivery/app/server.go
@@ -108,6 +108,10 @@ func Run(opt *options.ServerOption) error {
 			continue
 		}
 		lines := strings.SplitN(string(line), " ", 2)
+		// When using Intel MPI or MPICH, the hostfile format is hostname:slots, so need spliting the line by colon.
+		if strings.Contains(lines[0], ":") {
+			lines = strings.SplitN(string(line), ":", 2)
+		}
 		if !strings.HasSuffix(lines[0], launcherPodSuffix) {
 			pods = append(pods, lines[0])
 		}

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -73,9 +73,9 @@ type MPIJobSpec struct {
 	// the following fields: `BackoffLimit` and `ActiveDeadlineSeconds`.
 	RunPolicy *common.RunPolicy `json:"runPolicy,omitempty"`
 
-	// MPIDistribution specifies name of the mpi framwork which is used
-	// Deafults to "OpenMPI"
-	// Option includes "OpenMPI", "IntelMPI" and "MPICH"
+	// MPIDistribution specifies name of the MPI framwork which is used
+	// Defaults to "open_mpi"
+	// Options includes "open_mpi", "intel_mpi" and "mpich"
 	MPIDistribution string `json:"mpiDistribution,omitempty"`
 }
 

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -76,7 +76,7 @@ type MPIJobSpec struct {
 	// MPIDistribution specifies name of the MPI framwork which is used
 	// Defaults to "open_mpi"
 	// Options includes "open_mpi", "intel_mpi" and "mpich"
-	MPIDistribution string `json:"mpiDistribution,omitempty"`
+	MPIDistribution *MPIDistributionType `json:"mpiDistribution,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.
@@ -88,4 +88,16 @@ const (
 
 	// MPIReplicaTypeWorker is the type for worker replicas.
 	MPIReplicaTypeWorker MPIReplicaType = "Worker"
+)
+
+// MPIDistributionType is the type for MPIDistribution.
+type MPIDistributionType string
+
+const(
+	// MPIDistributionTypeOpenMPI is the type for Open MPI.
+	MPIDistributionTypeOpenMPI MPIDistributionType = "open_mpi"
+	// MPIDistributionTypeIntelMPI is the type for Intel MPI.
+	MPIDistributionTypeIntelMPI MPIDistributionType = "intel_mpi"
+	// MPIDistributionTypeMPICH is the type for MPICh.
+	MPIDistributionTypeMPICH MPIDistributionType = "mpich"
 )

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -72,6 +72,11 @@ type MPIJobSpec struct {
 	// active. The policies specified in `RunPolicy` take precedence over
 	// the following fields: `BackoffLimit` and `ActiveDeadlineSeconds`.
 	RunPolicy *common.RunPolicy `json:"runPolicy,omitempty"`
+
+	// MPIDistribution specifies name of the mpi framwork which is used
+	// Deafults to "OpenMPI"
+	// Option includes "OpenMPI", "IntelMPI" and "MPICH"
+	MPIDistribution string `json:"mpiDistribution,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.

--- a/pkg/apis/kubeflow/v1alpha2/types.go
+++ b/pkg/apis/kubeflow/v1alpha2/types.go
@@ -74,8 +74,8 @@ type MPIJobSpec struct {
 	RunPolicy *common.RunPolicy `json:"runPolicy,omitempty"`
 
 	// MPIDistribution specifies name of the MPI framwork which is used
-	// Defaults to "open_mpi"
-	// Options includes "open_mpi", "intel_mpi" and "mpich"
+	// Defaults to "OpenMPI"
+	// Options includes "OpenMPI", "IntelMPI" and "MPICH"
 	MPIDistribution *MPIDistributionType `json:"mpiDistribution,omitempty"`
 }
 
@@ -95,9 +95,11 @@ type MPIDistributionType string
 
 const(
 	// MPIDistributionTypeOpenMPI is the type for Open MPI.
-	MPIDistributionTypeOpenMPI MPIDistributionType = "open_mpi"
+	MPIDistributionTypeOpenMPI MPIDistributionType = "OpenMPI"
+
 	// MPIDistributionTypeIntelMPI is the type for Intel MPI.
-	MPIDistributionTypeIntelMPI MPIDistributionType = "intel_mpi"
+	MPIDistributionTypeIntelMPI MPIDistributionType = "IntelMPI"
+
 	// MPIDistributionTypeMPICH is the type for MPICh.
-	MPIDistributionTypeMPICH MPIDistributionType = "mpich"
+	MPIDistributionTypeMPICH MPIDistributionType = "MPICH"
 )

--- a/pkg/controllers/kubectl_delivery/controller.go
+++ b/pkg/controllers/kubectl_delivery/controller.go
@@ -152,7 +152,7 @@ func (c *KubectlDeliveryController) Run(threadiness int, stopCh <-chan struct{})
 					klog.Fatalf("Error read file[%s]: %v", "/etc/hosts", err)
 				}
 				defer fd.Close()
-				// Read the last line of local hosts file
+				// Read the last line of hosts file -- the ip address of localhost
 				scanner := bufio.NewScanner(fd)
 				for scanner.Scan() {
 					hosts = scanner.Text()
@@ -165,7 +165,7 @@ func (c *KubectlDeliveryController) Run(threadiness int, stopCh <-chan struct{})
 					}
 					hosts = fmt.Sprintf("%s\n%s\t%s", hosts, pod.Status.PodIP, pod.Name)
 				}
-				// Write all the hosts-format ip record to volume, and will be sent to worker later.
+				// Write the hosts-format ip record to volume, and will be sent to worker later.
 				fp, err := os.OpenFile("/opt/kube/hosts", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 				if err != nil {
 					klog.Fatalf("Error write file[%s]: %v", "/opt/kube/hosts", err)

--- a/pkg/controllers/kubectl_delivery/controller.go
+++ b/pkg/controllers/kubectl_delivery/controller.go
@@ -168,10 +168,13 @@ func (c *KubectlDeliveryController) Run(threadiness int, stopCh <-chan struct{})
 				// Write the hosts-format ip record to volume, and will be sent to worker later.
 				fp, err := os.OpenFile("/opt/kube/hosts", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 				if err != nil {
-					klog.Fatalf("Error write file[%s]: %v", "/opt/kube/hosts", err)
+					klog.Fatalf("Error create file[%s]: %v", "/opt/kube/hosts", err)
 				}
 				defer fp.Close()
-				fp.WriteString(hosts)
+				_, err = fp.WriteString(hosts)
+				if err!= nil{
+					klog.Fatalf("Error write file[%s]: %v", "/opt/kube/hosts", err)
+				}
 				klog.Info("Shutting down workers")
 				return nil
 			}

--- a/pkg/controllers/kubectl_delivery/controller.go
+++ b/pkg/controllers/kubectl_delivery/controller.go
@@ -144,7 +144,9 @@ func (c *KubectlDeliveryController) Run(threadiness int, stopCh <-chan struct{})
 			return nil
 		case <-ticker.C:
 			if len(c.watchedPods) == 0 {
-				c.generateHosts("/etc/hosts", "/opt/kube/hosts", workerPods)
+				if err := c.generateHosts("/etc/hosts", "/opt/kube/hosts", workerPods); err != nil {
+					return fmt.Errorf("Error generating hosts file: %v", err)
+				}
 				klog.Info("Shutting down workers")
 				return nil
 			}
@@ -162,8 +164,7 @@ func (c *KubectlDeliveryController) generateHosts(localHostsPath string, filePat
 	// First, open local hosts file to read launcher pod ip
 	fd, err := os.Open(localHostsPath)
 	if err != nil {
-		klog.Fatalf("Error read file[%s]: %v", localHostsPath, err)
-		return err
+		return fmt.Errorf("can't open file[%s]: %v", localHostsPath, err)
 	}
 	defer fd.Close()
 	// Read the last line of hosts file -- the ip address of localhost
@@ -175,18 +176,19 @@ func (c *KubectlDeliveryController) generateHosts(localHostsPath string, filePat
 	for index := range workerPods {
 		pod, err := c.podLister.Pods(c.namespace).Get(workerPods[index])
 		if err != nil {
-			continue
+			return fmt.Errorf("can't get IP address of node[%s]", workerPods[index])
 		}
 		hosts = fmt.Sprintf("%s\n%s\t%s", hosts, pod.Status.PodIP, pod.Name)
 	}
 	// Write the hosts-format ip record to volume, and will be sent to worker later.
 	fp, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		klog.Fatalf("Error write file[%s]: %v", filePath, err)
-		return err
+		return fmt.Errorf("can't create file[%s]: %v", filePath, err)
 	}
 	defer fp.Close()
-	fp.WriteString(hosts)
+	if _, err := fp.WriteString(hosts); err != nil {
+		return fmt.Errorf("can't write file[%s]: %v", filePath, err)
+	}
 	return nil
 }
 

--- a/pkg/controllers/kubectl_delivery/controller_test.go
+++ b/pkg/controllers/kubectl_delivery/controller_test.go
@@ -15,6 +15,10 @@
 package kubectl_delivery
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,4 +41,58 @@ func TestWaitingPodRunning(t *testing.T) {
 	fakePod.Status.Phase = corev1.PodRunning
 	f.setUpPods(fakePod)
 	f.run(namespace, podName)
+}
+
+// Test hosts file generating function
+func TestGeneratingHostsFile(t *testing.T) {
+	namespace := "default"
+	podNames := []string{"test", "tester-2", "worker_3", "pod4"}
+	// content of fake local hosts file
+	content := []byte(`# this line is a comment
+	127.0.0.1       localhost
+	::1							localhost
+	234.98.76.54		uselesshost
+	10.234.56.78		launcher.fullname.test	launcher`)
+
+	// content of excepted outputs
+	exceptedHosts := make(map[string]string)
+	exceptedHosts["launcher"] = "10.234.56.78"
+	exceptedHosts["launcher.fullname.test"] = "10.234.56.78"
+	f := newFixture(t)
+	// add fake worker pods
+	fakePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+		},
+	}
+	fakePod.Status.Phase = corev1.PodRunning
+	for index := range podNames {
+		fakePod.Status.PodIP = "123.123.123." + strconv.Itoa(index)
+		fakePod.ObjectMeta.Name = podNames[index]
+		exceptedHosts[fakePod.ObjectMeta.Name] = fakePod.Status.PodIP
+		f.setUpPods(fakePod.DeepCopy())
+	}
+	// set up temp directory for testing about files
+	p, tmphf := f.setUpTmpDir("hostsGenerating", content)
+	defer os.RemoveAll(p) // clean up the temp directory
+	tmpof := filepath.Join(p, "output")
+	c, _ := f.newController(namespace, podNames)
+	// generate new hosts file
+	err := c.generateHosts(tmphf, tmpof, podNames)
+	if err != nil {
+		t.Errorf("Error, cannot generating hosts of worker pods, errs: %v", err)
+	}
+	// get the output file content
+	outputContent, err := ioutil.ReadFile(tmpof)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// slice the content of output to avoid space/tab interference
+	generatedHosts := f.getResolvedHosts(outputContent)
+	// check the output
+	for hostname, exceptedIP := range exceptedHosts {
+		if resolvedIP, ok := generatedHosts[hostname]; !ok || resolvedIP != exceptedIP {
+			t.Errorf("Error, generated hosts file incorrect. Host: %s, excepted: %s, resolved: %s", hostname, exceptedIP, resolvedIP)
+		}
+	}
 }

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1302,8 +1302,8 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 	// to specify the path of the remote task launcher and hostfile file.
 	mpiRshExecPathEnvName := "OMPI_MCA_plm_rsh_agent"
 	mpiHostfilePathEnvName := "OMPI_MCA_orte_default_hostfile"
-	// If the MPIDistribution is not specificed as the kubeflow.MPIDistributionTypeIntelMPI or "mpich",
-	// then think that the default "open_mpi" will be used.
+	// If the MPIDistribution is not specificed as the "IntelMPI" or "MPICH",
+	// then think that the default "OpenMPI" will be used.
 	if mpiJob.Spec.MPIDistribution != nil {
 		if *mpiJob.Spec.MPIDistribution == kubeflow.MPIDistributionTypeIntelMPI {
 			mpiRshExecPathEnvName = "I_MPI_HYDRA_BOOTSTRAP_EXEC"

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -959,13 +959,13 @@ func (c *MPIJobController) doUpdateJobStatus(mpiJob *kubeflow.MPIJob) error {
 // handleObject can discover the MPIJob resource that 'owns' it.
 func newConfigMap(mpiJob *kubeflow.MPIJob, workerReplicas int32) *corev1.ConfigMap {
 	var kubexec string
-	if mpiJob.Spec.MPIDistribution == "IntelMPI"{
+	if mpiJob.Spec.MPIDistribution == "intel_mpi"{
 		kubexec = fmt.Sprintf(`#!/bin/sh
 set -x
 POD_NAME=$3
 shift 3
 %s/kubectl exec ${POD_NAME}`, kubectlMountPath)
-	}else if mpiJob.Spec.MPIDistribution == "MPICH" {
+	}else if mpiJob.Spec.MPIDistribution == "mpich" {
 		kubexec = fmt.Sprintf(`#!/bin/sh
 set -x
 POD_NAME=$2
@@ -991,7 +991,7 @@ shift
 	}
 	var buffer bytes.Buffer
 	for i := 0; i < int(workerReplicas); i++ {
-		if mpiJob.Spec.MPIDistribution == "IntelMPI" || mpiJob.Spec.MPIDistribution == "MPICH" {
+		if mpiJob.Spec.MPIDistribution == "intel_mpi" || mpiJob.Spec.MPIDistribution == "mpich" {
 			buffer.WriteString(fmt.Sprintf("%s%s-%d:%d\n", mpiJob.Name, workerSuffix, i, slots))
 		}else{
 			buffer.WriteString(fmt.Sprintf("%s%s-%d slots=%d\n", mpiJob.Name, workerSuffix, i, slots))
@@ -1300,10 +1300,10 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 	container := podSpec.Spec.Containers[0]
 	var mpiRshExecPathEnvName string
 	var mpiHostfilePathEnvName string
-	if mpiJob.Spec.MPIDistribution == "IntelMPI" {
+	if mpiJob.Spec.MPIDistribution == "intel_mpi" {
 		mpiRshExecPathEnvName = "I_MPI_HYDRA_BOOTSTRAP_EXEC"
 		mpiHostfilePathEnvName = "I_MPI_HYDRA_HOST_FILE"
-	}else if mpiJob.Spec.MPIDistribution == "MPICH" {
+	}else if mpiJob.Spec.MPIDistribution == "mpich" {
 		mpiRshExecPathEnvName = "HYDRA_LAUNCHER_EXEC"
 		mpiHostfilePathEnvName = "HYDRA_HOST_FILE"
 	}else{

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1298,25 +1298,25 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 		return nil
 	}
 	container := podSpec.Spec.Containers[0]
-	var mpiRshExecPath string
-	var mpiHostfilePath string
+	var mpiRshExecPathEnvName string
+	var mpiHostfilePathEnvName string
 	if mpiJob.Spec.MPIDistribution == "IntelMPI" {
-		mpiRshExecPath = "I_MPI_HYDRA_BOOTSTRAP_EXEC"
-		mpiHostfilePath = "I_MPI_HYDRA_HOST_FILE"
+		mpiRshExecPathEnvName = "I_MPI_HYDRA_BOOTSTRAP_EXEC"
+		mpiHostfilePathEnvName = "I_MPI_HYDRA_HOST_FILE"
 	}else if mpiJob.Spec.MPIDistribution == "MPICH" {
-		mpiRshExecPath = "HYDRA_LAUNCHER_EXEC"
-		mpiHostfilePath = "HYDRA_HOST_FILE"
+		mpiRshExecPathEnvName = "HYDRA_LAUNCHER_EXEC"
+		mpiHostfilePathEnvName = "HYDRA_HOST_FILE"
 	}else{
-		mpiRshExecPath = "OMPI_MCA_plm_rsh_agent"
-		mpiHostfilePath = "OMPI_MCA_orte_default_hostfile"
+		mpiRshExecPathEnvName = "OMPI_MCA_plm_rsh_agent"
+		mpiHostfilePathEnvName = "OMPI_MCA_orte_default_hostfile"
 	}
 	container.Env = append(container.Env,
 		corev1.EnvVar{
-			Name:  mpiRshExecPath,
+			Name:  mpiRshExecPathEnvName,
 			Value: fmt.Sprintf("%s/%s", configMountPath, kubexecScriptName),
 		},
 		corev1.EnvVar{
-			Name:  mpiHostfilePath,
+			Name:  mpiHostfilePathEnvName,
 			Value: fmt.Sprintf("%s/%s", configMountPath, hostfileName),
 		},
 		// We overwrite these environment variables so that users will not

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -958,7 +958,7 @@ func (c *MPIJobController) doUpdateJobStatus(mpiJob *kubeflow.MPIJob) error {
 // resource. It also sets the appropriate OwnerReferences on the resource so
 // handleObject can discover the MPIJob resource that 'owns' it.
 func newConfigMap(mpiJob *kubeflow.MPIJob, workerReplicas int32) *corev1.ConfigMap {
-	var kubexec string = ""
+	var kubexec string
 	if mpiJob.Spec.MPIDistribution == "IntelMPI"{
 		kubexec = fmt.Sprintf(`#!/bin/sh
 set -x

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -960,7 +960,7 @@ func (c *MPIJobController) doUpdateJobStatus(mpiJob *kubeflow.MPIJob) error {
 func newConfigMap(mpiJob *kubeflow.MPIJob, workerReplicas int32) *corev1.ConfigMap {
 	// This part closely related to specific ssh commands.
 	// It is very likely to fail due to the version change of the MPI framework.
-	// Attempt to automatically filter prefix parameters by detecting "-" matches
+	// Attempt to automatically filter prefix parameters by detecting "-" matches.
 	kubexec := fmt.Sprintf(`#!/bin/sh
 set -x
 POD_NAME=$1
@@ -982,8 +982,9 @@ shift
 		slots = int(*mpiJob.Spec.SlotsPerWorker)
 	}
 	var buffer bytes.Buffer
-	// For the different MPI frameworks, the format of the hostfile file is inconsistent.
-	// For Intel MPI and MVAPICH2, use ":" syntax to indicate how many operating slots the current node has.
+	// According to the specified MPI framework, construct a host file that meets the format requirements.
+	// For Intel MPI and MVAPICH2 (Basically follow the MPICH standard),
+	// use ":" syntax to indicate how many operating slots the current node has.
 	// But for Open MPI, use "slots=" syntax to achieve this function.
 	for i := 0; i < int(workerReplicas); i++ {
 		if mpiJob.Spec.MPIDistribution == "intel_mpi" || mpiJob.Spec.MPIDistribution == "mpich" {


### PR DESCRIPTION
Ther major differences in the launching process between the ompi, intel-mpi and mvapich are:
- the envrionment variable name 
- the ssh/rsh launching command and hostfile format

For intel-mpi and mvapich, hydra process manager is used, instead of orted. However, there's no major difference in the ssh/rsh command that launches a remote process manager, with the only thing needed caring is the position of remote pod name arugment.
(Unfortunately, it seems that in the intel-mpi@2020 version, the ssh/rsh command has changed again and the prefix arguments "-q -x" have been abandoned. It's such a mess.)

As for the the envrionment variable name, both intel-mpi and mvapich have the samily functional one.

And as I have not found a effective way to auto-detect the mpi distribution, so a new argument is added to the api.

there're some docker images that I build and use to test the code.
https://hub.docker.com/repository/docker/milkybird98/ompi-osu
https://hub.docker.com/repository/docker/milkybird98/intel-mpi-osu
https://hub.docker.com/repository/docker/milkybird98/mvapich2-osu