### PR TITLE
Fix additional printer columns in v1 CRD

### DIFF
--- a/deploy/v1/mpi-operator.yaml
+++ b/deploy/v1/mpi-operator.yaml
@@ -12,6 +12,10 @@ kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org
 spec:
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   group: kubeflow.org
   version: v1
   scope: Namespaced
@@ -45,10 +49,6 @@ spec:
                     replicas:
                       type: integer
                       minimum: 1
-    additionalPrinterColumns:
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
`additionalPrinterColumns` should be under `.spec` in `CustomResourceDefinition`.
I also fixed `JSONPath` param name.

/cc @terrytangyuan @carmark 