### PR TITLE
Change horovod example to V1

### DIFF
--- a/examples/horovod/Dockerfile.cpu
+++ b/examples/horovod/Dockerfile.cpu
@@ -4,6 +4,7 @@ ENV TENSORFLOW_VERSION=1.14.0
 ENV PYTORCH_VERSION=1.4.0
 ENV TORCHVISION_VERSION=0.5.0
 ENV MXNET_VERSION=1.6.0
+ENV HOROVOD_VERSION=0.19.0
 
 # Python 2.7 or 3.6 is supported by Ubuntu Bionic out of the box
 ARG python=3.6
@@ -61,7 +62,7 @@ RUN mkdir /tmp/openmpi && \
 
 # Install Horovod
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 \
-    pip install --no-cache-dir horovod
+    pip install --no-cache-dir horovod==${HOROVOD_VERSION}
 
 # Install OpenSSH for MPI to communicate between containers
 RUN apt-get install -y --no-install-recommends openssh-client openssh-server && \

--- a/examples/horovod/tensorflow-mnist.yaml
+++ b/examples/horovod/tensorflow-mnist.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v1alpha2
+apiVersion: kubeflow.org/v1
 kind: MPIJob
 metadata:
   name: tensorflow-mnist

--- a/examples/horovod/tensorflow-mnist.yaml
+++ b/examples/horovod/tensorflow-mnist.yaml
@@ -11,7 +11,7 @@ spec:
       template:
         spec:
           containers:
-          - image: horovod-cpu:latest
+          - image: docker.io/kubeflow/mpi-horovod-mnist
             name: mpi-launcher
             command:
             - mpirun
@@ -44,7 +44,7 @@ spec:
       template:
         spec:
           containers:
-          - image: horovod-cpu:latest
+          - image: docker.io/kubeflow/mpi-horovod-mnist
             name: mpi-worker
             resources:
               limits:


### PR DESCRIPTION
I made few changes in horovod example.

1. Switch to v1 from v1alpha2. I was tested in the new CRD and example is working.
2. Add `HOROVOD_VERSION` to Dockerfile. Horovod dropped Tensorflow < 1.15 support in the latest vesrion (ref: https://github.com/horovod/horovod/releases/tag/v0.20.0). I was not able to build latest [Docker image from horovod](https://github.com/horovod/horovod/blob/master/Dockerfile.cpu), but I was able to build image with 0.19.0 version.
3. Add `lr` and `num-steps` as input parameters in mnist example. We will use them as HP in Katib.

Also, I can't pull images from `horovod-cpu:latest` repo.

@terrytangyuan @carmark Do you have any registry to push examples images or we should use our own ?
For example, in Katib we have this registry: https://hub.docker.com/u/kubeflowkatib

/assign @terrytangyuan @carmark 
