### PR TITLE
Explicitly pass namespaces to MPI Operator's deployment

### DIFF
--- a/deploy/v1/mpi-operator.yaml
+++ b/deploy/v1/mpi-operator.yaml
@@ -192,6 +192,10 @@ spec:
         args: [
           "-alsologtostderr",
           "--kubectl-delivery-image",
-          "mpioperator/kubectl-delivery:latest"
+          "mpioperator/kubectl-delivery:latest",
+          "--namespace",
+          "mpi-operator",
+          "--lock-namespace",
+          "mpi-operator"
         ]
         imagePullPolicy: Always


### PR DESCRIPTION
It's better to make these args explicit so that users know these need to be changed if they use a different namespace.