### PR TITLE
fix: it panics if workerSpec.Replicas is unset

### DIFF
--- a/pkg/controllers/v1/mpi_job_controller.go
+++ b/pkg/controllers/v1/mpi_job_controller.go
@@ -525,7 +525,7 @@ func (c *MPIJobController) syncHandler(key string) error {
 	if !done {
 		workerSpec := mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker]
 		workerReplicas := int32(0)
-		if workerSpec != nil {
+		if workerSpec != nil && workerSpec.Replicas != nil {
 			workerReplicas = *workerSpec.Replicas
 		}
 		isGPULauncher := isGPULauncher(mpiJob) && c.launcherRunsWorkload


### PR DESCRIPTION
Hi, I use SDK v1 to create a job like:

```
&mpijobv1.MPIJob{
		TypeMeta: metav1.TypeMeta{
			Kind:       Kind,
			APIVersion: APIVersion,
		},
		ObjectMeta: metav1.ObjectMeta{
			Name:         jobname,
			GenerateName: info.Name,
			Namespace:    info.Username,
			Labels:       map[string]string{},
			Annotations:  map[string]string{},
		},
		Spec: mpijobv1.MPIJobSpec{
			SlotsPerWorker: pointer.Int32Ptr(info.Slots),
			CleanPodPolicy: func() *common.CleanPodPolicy { p := common.CleanPodPolicyRunning; return &p }(),
			MPIReplicaSpecs: map[mpijobv1.MPIReplicaType]*common.ReplicaSpec{
				mpijobv1.MPIReplicaTypeLauncher: &launcher,
				mpijobv1.MPIReplicaTypeWorker:   &worker,
			},
			MainContainer: "",
			RunPolicy:     &common.RunPolicy{},
		},
		Status: common.JobStatus{},
	}
```

But the `worker` is empty. Finally, it will panic. So I fix it.
PTAL, thanks.
