### PR TITLE
Fixed golangci lint issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 _output/
 bin/
+profile.cov

--- a/pkg/controllers/v1alpha2/mpi_job_controller.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller.go
@@ -1388,8 +1388,7 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, kubectlDeliveryI
 	backOffLimit := mpiJob.Spec.BackoffLimit
 	activeDeadlineSeconds := mpiJob.Spec.ActiveDeadlineSeconds
 	if mpiJob.Spec.RunPolicy != nil {
-		warnMsg := fmt.Sprintf(
-			"runPolicy is specified in MPIJobSpec so backOffLimit/activeDeadlineSeconds in MPIJobSpec will be overwritten")
+		warnMsg := "runPolicy is specified in MPIJobSpec so backOffLimit/activeDeadlineSeconds in MPIJobSpec will be overwritten"
 		klog.Warning(warnMsg)
 		if mpiJob.Spec.RunPolicy.BackoffLimit != nil {
 			backOffLimit = mpiJob.Spec.RunPolicy.BackoffLimit


### PR DESCRIPTION
Fixed the golangci lint issue https://github.com/kubeflow/mpi-operator/issues/307

Also, update the .gitignore to ignore the coverage file which was from the tests.