### PR TITLE
fix role updating issue

### DIFF
--- a/examples/horovod/tensorflow-mnist-elastic.yaml
+++ b/examples/horovod/tensorflow-mnist-elastic.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubeflow.org/v1
 kind: MPIJob
 metadata:
-  name: tensorflow-mnist
+  name: tensorflow-mnist-elastic
 spec:
   slotsPerWorker: 1
   cleanPodPolicy: Running
@@ -11,17 +11,21 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-horovod-mnist
+          - image: horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu
             name: mpi-launcher
             command:
             - horovodrun
             args:
             - -np
             - "2"
+            - min-np
+            - "1"
+            - max-np
+            - "3"
             - --host-discovery-script
             - /etc/mpi/discover_hosts.sh
             - python
-            - /examples/tensorflow_mnist.py
+            - /examples/elastic/tensorflow2_mnist_elastic.py
             resources:
               limits:
                 cpu: 1
@@ -31,7 +35,7 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-horovod-mnist
+          - image: horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu
             name: mpi-worker
             resources:
               limits:

--- a/pkg/controllers/v1/mpi_job_controller_test.go
+++ b/pkg/controllers/v1/mpi_job_controller_test.go
@@ -572,10 +572,11 @@ func TestConfigMapNotControlledByUs(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(64), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 64
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 64, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	configMap.OwnerReferences = nil
 	f.setUpConfigMap(configMap)
@@ -588,10 +589,11 @@ func TestServiceAccountNotControlledByUs(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(64), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 64
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 64, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
 
@@ -607,15 +609,16 @@ func TestRoleNotControlledByUs(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(64), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 64
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 64, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
 	f.setUpServiceAccount(newLauncherServiceAccount(mpiJob))
 
-	role := newLauncherRole(mpiJob, 8)
+	role := newLauncherRole(mpiJob, replicas)
 	role.OwnerReferences = nil
 	f.setUpRole(role)
 
@@ -627,14 +630,15 @@ func TestRoleBindingNotControlledByUs(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(64), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 64
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 64, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
 	f.setUpServiceAccount(newLauncherServiceAccount(mpiJob))
-	f.setUpRole(newLauncherRole(mpiJob, 8))
+	f.setUpRole(newLauncherRole(mpiJob, replicas))
 
 	roleBinding := newLauncherRoleBinding(mpiJob)
 	roleBinding.OwnerReferences = nil
@@ -648,7 +652,8 @@ func TestShutdownWorker(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(8), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 8
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	msg := fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
 	err := updateMPIJobConditions(mpiJob, common.JobSucceeded, mpiJobSucceededReason, msg)
 	if err != nil {
@@ -661,7 +666,7 @@ func TestShutdownWorker(t *testing.T) {
 	launcher.Status.Phase = corev1.PodSucceeded
 	f.setUpLauncher(launcher)
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < int(replicas); i++ {
 		name := fmt.Sprintf("%s-%d", mpiJob.Name+workerSuffix, i)
 		worker := newWorker(mpiJob, name, "")
 		f.setUpWorker(worker)
@@ -672,7 +677,7 @@ func TestShutdownWorker(t *testing.T) {
 			t.Errorf("Failed to delete worker: %v", err)
 		}
 	*/
-	for i := 0; i < 8; i++ {
+	for i := 0; i < int(replicas); i++ {
 		name := fmt.Sprintf("%s-%d", mpiJob.Name+workerSuffix, i)
 		f.kubeActions = append(f.kubeActions, core.NewDeleteAction(schema.GroupVersionResource{Resource: "pods"}, mpiJob.Namespace, name))
 	}
@@ -696,15 +701,16 @@ func TestWorkerNotControlledByUs(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(64), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 8
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 64, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
-	f.setUpRbac(mpiJob, 8)
+	f.setUpRbac(mpiJob, replicas)
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < int(replicas); i++ {
 		name := fmt.Sprintf("%s-%d", mpiJob.Name+workerSuffix, i)
 		worker := newWorker(mpiJob, name, "")
 		worker.OwnerReferences = nil
@@ -719,20 +725,21 @@ func TestLauncherActiveWorkerNotReady(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(8), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 8
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	configMap := newConfigMap(mpiJob, 8, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, nil, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
-	f.setUpRbac(mpiJob, 1)
+	f.setUpRbac(mpiJob, replicas)
 
 	fmjc := f.newFakeMPIJobController()
 	launcher := fmjc.newLauncher(mpiJob, "kubectl-delivery", isGPULauncher(mpiJob))
 	launcher.Status.Phase = corev1.PodRunning
 	f.setUpLauncher(launcher)
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < int(replicas); i++ {
 		name := fmt.Sprintf("%s-%d", mpiJob.Name+workerSuffix, i)
 		worker := newWorker(mpiJob, name, "")
 		worker.Status.Phase = corev1.PodPending
@@ -762,10 +769,11 @@ func TestLauncherActiveWorkerReady(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(8), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 8
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	f.setUpRbac(mpiJob, 1)
+	f.setUpRbac(mpiJob, replicas)
 
 	fmjc := f.newFakeMPIJobController()
 	launcher := fmjc.newLauncher(mpiJob, "kubectl-delivery", isGPULauncher(mpiJob))
@@ -773,7 +781,7 @@ func TestLauncherActiveWorkerReady(t *testing.T) {
 	f.setUpLauncher(launcher)
 
 	var runningPodList []*corev1.Pod
-	for i := 0; i < 8; i++ {
+	for i := 0; i < int(replicas); i++ {
 		name := fmt.Sprintf("%s-%d", mpiJob.Name+workerSuffix, i)
 		worker := newWorker(mpiJob, name, "")
 		worker.Status.Phase = corev1.PodRunning
@@ -781,7 +789,7 @@ func TestLauncherActiveWorkerReady(t *testing.T) {
 		f.setUpWorker(worker)
 	}
 
-	configMap := newConfigMap(mpiJob, 8, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, runningPodList, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
 
@@ -814,10 +822,11 @@ func TestWorkerReady(t *testing.T) {
 	startTime := metav1.Now()
 	completionTime := metav1.Now()
 
-	mpiJob := newMPIJob("test", int32Ptr(16), 1, gpuResourceName, &startTime, &completionTime)
+	var replicas int32 = 16
+	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	f.setUpMPIJob(mpiJob)
 
-	f.setUpRbac(mpiJob, 16)
+	f.setUpRbac(mpiJob, replicas)
 
 	var runningPodList []*corev1.Pod
 	for i := 0; i < 16; i++ {
@@ -828,7 +837,7 @@ func TestWorkerReady(t *testing.T) {
 		f.setUpWorker(worker)
 	}
 
-	configMap := newConfigMap(mpiJob, 16, isGPULauncher(mpiJob))
+	configMap := newConfigMap(mpiJob, replicas, isGPULauncher(mpiJob))
 	updateDiscoverHostsInConfigMap(configMap, mpiJob, runningPodList, isGPULauncher(mpiJob))
 	f.setUpConfigMap(configMap)
 


### PR DESCRIPTION
When worker replicas is scaled up, the rules in the role associated with the launcher pod needs to be update with the new worker pods, enable `horovodrun` to execute command in new worker pods via `kubectl`.

- [x] fix updating rules in role
- [x] fix elastic training example