### PR TITLE
fix --min-np and --max-np args in elastic example

### DIFF
--- a/examples/horovod/tensorflow-mnist-elastic.yaml
+++ b/examples/horovod/tensorflow-mnist-elastic.yaml
@@ -18,9 +18,9 @@ spec:
             args:
             - -np
             - "2"
-            - min-np
+            - --min-np
             - "1"
-            - max-np
+            - --max-np
             - "3"
             - --host-discovery-script
             - /etc/mpi/discover_hosts.sh


### PR DESCRIPTION
Fix the missing `--` before `min-np` and `max-np`.