### PR TITLE
Add development options to build system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,28 @@ You can execute all the unit tests via `go test ./...`.
 ## Check Code Style
 
 We use [golangci-lint](https://github.com/golangci/golangci-lint) to check issues on code style. Please also check out [this wiki](https://github.com/golang/go/wiki/CodeReviewComments) for some additional instructions on code review.
+
+## Run
+
+You have to build the image and deploy the standalone YAMLs in a cluster.
+
+```shell
+CONTROLLER_VERSION=v1 RELEASE_VERSION=latest make images
+kubectl apply -k manifests/overlays/standalone
+```
+
+If you need to use a different registry, you can do:
+
+```shell
+IMAGE_NAME=example.com/mpi-operator CONTROLLER_VERSION=v1 RELEASE_VERSION=latest make images
+```
+
+Next, modify the line `newName` in `manifests/overlays/standalone/kustomization.yaml`
+to match the image name. After pushing the image to the registry, you can apply
+the YAMLs the same way as before.
+
+To look at the controller's logs, you can do:
+
+```shell
+kubectl logs -n mpi-operator -f deployment/mpi-operator
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM golang:1.13.6 AS build
-  
+ARG version=v1alpha2
+
 ADD . /go/src/github.com/kubeflow/mpi-operator
 WORKDIR /go/src/github.com/kubeflow/mpi-operator
-RUN make
+RUN make mpi-operator.$version
 
 FROM gcr.io/distroless/base-debian10:latest
-COPY --from=build /go/src/github.com/kubeflow/mpi-operator/_output/cmd/bin/mpi-operator.* /opt/
+ARG version=v1alpha2
+COPY --from=build /go/src/github.com/kubeflow/mpi-operator/_output/cmd/bin/mpi-operator.$version /opt/mpi-operator
 COPY third_party/library/license.txt /opt/license.txt
 
-ENTRYPOINT ["/opt/mpi-operator.v1alpha2"]
+ENTRYPOINT ["/opt/mpi-operator"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ REPO_PATH="github.com/kubeflow/mpi-operator"
 REL_OSARCH="linux/amd64"
 GitSHA=`git rev-parse HEAD`
 Date=`date "+%Y-%m-%d %H:%M:%S"`
-RELEASE_VERSION=v0.2.2
+RELEASE_VERSION?=v0.2.2
+CONTROLLER_VERSION?=v1alpha2
 IMG_BUILDER=docker
 LD_FLAGS=" \
     -X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
@@ -49,7 +50,7 @@ clean:
 
 images:
 	@echo "version: ${RELEASE_VERSION}"
-	${IMG_BUILDER} build -t ${IMAGE_NAME}:${RELEASE_VERSION} .
+	${IMG_BUILDER} build --build-arg version=${CONTROLLER_VERSION} -t ${IMAGE_NAME}:${RELEASE_VERSION} .
 
 tidy:
 	go mod tidy

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -14,14 +14,20 @@ rules:
   - create
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
+  - create
   - get
   - list
   - watch
+  - delete
+  - update
+  - patch
+# This is needed for the launcher Role.
 - apiGroups:
   - ""
   resources:

--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -12,6 +12,8 @@ spec:
     shortNames:
     - mj
     - mpij
+  subresources:
+    status: {}
   versions:
   - name: v1alpha1
     served: false

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -11,7 +11,7 @@ commonLabels:
   app.kubernetes.io/component: mpijob
 images:
 - name: mpioperator/mpi-operator
-  newName: mpioperator/mpi-operator
+  newName: gcr.io/acondor-gke-dev/mpi-operator
   newTag: latest
 configMapGenerator:
 - name: mpi-operator-config

--- a/manifests/overlays/dev/namespace.yaml
+++ b/manifests/overlays/dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mpi-operator

--- a/manifests/overlays/dev/params.env
+++ b/manifests/overlays/dev/params.env
@@ -1,0 +1,1 @@
+lock-namespace=mpi-operator

--- a/manifests/overlays/standalone/params.env
+++ b/manifests/overlays/standalone/params.env
@@ -1,0 +1,1 @@
+lock-namespace=mpi-operator


### PR DESCRIPTION
Add development options to build system and fix CRD and ClusterRole on kustomize.

- The Makefile can now be used to build images with different controller versions.
- Fixed kustomize ClusterRole to include missing update and create permissions
- Fixed kustomize CRD to include the status subresource
- Added development instructions