### PR TITLE
Revert horovod example to v1

### DIFF
--- a/examples/horovod/tensorflow-mnist.yaml
+++ b/examples/horovod/tensorflow-mnist.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v2
+apiVersion: kubeflow.org/v1
 kind: MPIJob
 metadata:
   name: tensorflow-mnist
@@ -15,6 +15,7 @@ spec:
             name: mpi-launcher
             command:
             - mpirun
+            args:
             - -np
             - "2"
             - --allow-run-as-root


### PR DESCRIPTION
The controller generates keys and mounts them to the containers. The container images must know how to place the credentials and set file permissions.

First part of #373 (Replace kubectl and support roles with ssh and secrets)

Tested with the horovod CPU image