### PR TITLE
Upgrade to apiextensions.k8s.io/v1

### DIFF
--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org
@@ -12,164 +12,181 @@ spec:
     shortNames:
     - mj
     - mpij
-  subresources:
-    status: {}
   versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            title: The MPIJob spec
-            description: Only one of gpus, processingUnits, or replicas should be specified
-            oneOf:
-            - properties:
-                gpus:
-                  title: Total number of GPUs
-                  description: Valid values are 1, 2, 4, or any multiple of 8
-                  oneOf:
-                  - type: integer
-                    enum:
-                    - 1
-                    - 2
-                    - 4
-                  - type: integer
-                    multipleOf: 8
-                    minimum: 8
-                slotsPerWorker:
-                  title: The number of slots per worker used in hostfile
-                  description: Defaults to the number of processing units per worker
-                  type: integer
-                  minimum: 1
-                gpusPerNode:
-                  title: The maximum number of GPUs available per node
-                  description: Defaults to the number of GPUs per worker
-                  type: integer
-                  minimum: 1
-              required:
-              - gpus
-            - properties:
-                processingUnits:
-                  title: Total number of processing units
-                  description: Valid values are 1, 2, 4, or any multiple of 8
-                  oneOf:
-                  - type: integer
-                    enum:
-                    - 1
-                    - 2
-                    - 4
-                  - type: integer
-                    multipleOf: 8
-                    minimum: 8
-                slotsPerWorker:
-                  title: The number of slots per worker used in hostfile
-                  description: Defaults to the number of processing units per worker
-                  type: integer
-                  minimum: 1
-                processingUnitsPerNode:
-                  title: The maximum number of processing units available per node
-                  description: Defaults to the number of processing units per worker
-                  type: integer
-                  minimum: 1
-                processingResourceType:
-                  title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
-                  description: Defaults to 'nvidia.com/gpu'
-                  type: string
-                  enum:
-                  - nvidia.com/gpu
-                  - cpu
-              required:
-              - processingUnits
-            - properties:
-                replicas:
-                  title: Total number of replicas
-                  description: The processing resource limit should be specified for each replica
-                  type: integer
-                  minimum: 1
-                slotsPerWorker:
-                  title: The number of slots per worker used in hostfile
-                  description: Defaults to the number of processing units per worker
-                  type: integer
-                  minimum: 1
-                processingResourceType:
-                  title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
-                  description: Defaults to 'nvidia.com/gpu'
-                  type: string
-                  enum:
-                  - nvidia.com/gpu
-                  - cpu
-              required:
-              - replicas
   - name: v1alpha2
     served: true
     storage: false
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
             properties:
               slotsPerWorker:
                 type: integer
                 minimum: 1
               mpiReplicaSpecs:
+                type: object
                 properties:
                   Launcher:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
                     properties:
                       replicas:
                         type: integer
                         minimum: 1
                         maximum: 1
                   Worker:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
                     properties:
                       replicas:
                         type: integer
                         minimum: 1
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+    subresources:
+      status: {}
   - name: v1
     served: true
     storage: false
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
             properties:
               slotsPerWorker:
                 type: integer
                 minimum: 1
               mpiReplicaSpecs:
+                type: object
                 properties:
                   Launcher:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
                     properties:
                       replicas:
                         type: integer
                         minimum: 1
                         maximum: 1
                   Worker:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
                     properties:
                       replicas:
                         type: integer
+                        minimum: 1
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+    subresources:
+      status: {}
   - name: v2beta1
     served: true
     storage: true
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           spec:
+            type: object
             properties:
               slotsPerWorker:
                 type: integer
                 minimum: 1
+              cleanPodPolicy:
+                type: string
+                enum: ["None", "Running", "All"]
+                description: "Defines which Pods must be deleted after the Job completes"
               mpiReplicaSpecs:
+                type: object
                 properties:
                   Launcher:
+                    type: object
                     properties:
                       replicas:
                         type: integer
                         minimum: 1
                         maximum: 1
+                      template:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      restartPolicy:
+                        type: string
+                        enum: ["Never", "OnFailure", "Always"]
                   Worker:
+                    type: object
                     properties:
                       replicas:
                         type: integer
                         minimum: 1
+                      template:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      restartPolicy:
+                        type: string
+                        enum: ["Never", "OnFailure", "Always"]
+                required:
+                - Launcher
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum: ["Created", "Running", "Restarting", "Succeeded", "Failed"]
+                    status:
+                      type: string
+                      enum: ["True", "False", "Unknown"]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastUpdateTime:
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+              replicaStatuses:
+                type: object
+                properties:
+                  Launcher:
+                    type: object
+                    properties:
+                      active:
+                        type: integer
+                      succeeded:
+                        type: integer
+                      failed:
+                        type: integer
+                  Worker:
+                    type: object
+                    properties:
+                      active:
+                        type: integer
+                      succeeded:
+                        type: integer
+                      failed:
+                        type: integer
+              startTime:
+                type: string
+                format: date-time
+              completionTime:
+                type: string
+                format: date-time
+              lastReconcileTime:
+                type: string
+                format: date-time
+    subresources:
+      status: {}

--- a/v2/pkg/apis/kubeflow/v2beta1/types.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/types.go
@@ -51,15 +51,6 @@ type MPIJobSpec struct {
 	// `MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that
 	// specify the MPI replicas to run.
 	MPIReplicaSpecs map[MPIReplicaType]*common.ReplicaSpec `json:"mpiReplicaSpecs"`
-
-	// MainContainer specifies name of the main container which
-	// executes the MPI code.
-	MainContainer string `json:"mainContainer,omitempty"`
-
-	// `RunPolicy` encapsulates various runtime policies of the distributed training
-	// job, for example how to clean up resources and how long the job can stay
-	// active.
-	RunPolicy *common.RunPolicy `json:"runPolicy,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.

--- a/v2/pkg/apis/kubeflow/v2beta1/zz_generated.deepcopy.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/zz_generated.deepcopy.go
@@ -112,11 +112,6 @@ func (in *MPIJobSpec) DeepCopyInto(out *MPIJobSpec) {
 			(*out)[key] = outVal
 		}
 	}
-	if in.RunPolicy != nil {
-		in, out := &in.RunPolicy, &out.RunPolicy
-		*out = new(v1.RunPolicy)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 

--- a/v2/pkg/apis/kubeflow/validation/validation.go
+++ b/v2/pkg/apis/kubeflow/validation/validation.go
@@ -79,8 +79,8 @@ func validateWorkerReplicaSpec(spec *common.ReplicaSpec, path *field.Path) field
 		return errs
 	}
 	errs = append(errs, validateReplicaSpec(spec, path)...)
-	if spec.Replicas != nil {
-		errs = append(errs, apivalidation.ValidateNonnegativeField(int64(*spec.Replicas), path.Child("replicas"))...)
+	if spec.Replicas != nil && *spec.Replicas <= 0 {
+		errs = append(errs, field.Invalid(path.Child("replicas"), *spec.Replicas, "must be greater than or equal to 1"))
 	}
 	return errs
 }

--- a/v2/pkg/apis/kubeflow/validation/validation_test.go
+++ b/v2/pkg/apis/kubeflow/validation/validation_test.go
@@ -135,6 +135,42 @@ func TestValidateMPIJob(t *testing.T) {
 				},
 			},
 		},
+		"invalid replica counts": {
+			job: v2beta1.MPIJob{
+				Spec: v2beta1.MPIJobSpec{
+					SlotsPerWorker: newInt32(2),
+					CleanPodPolicy: newCleanPodPolicy(common.CleanPodPolicyRunning),
+					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
+						v2beta1.MPIReplicaTypeLauncher: {
+							Replicas: newInt32(2),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+						v2beta1.MPIReplicaTypeWorker: {
+							Replicas: newInt32(0),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErrs: field.ErrorList{
+				{
+					Type:  field.ErrorTypeInvalid,
+					Field: "spec.mpiReplicaSpecs[Launcher].replicas",
+				},
+				{
+					Type:  field.ErrorTypeInvalid,
+					Field: "spec.mpiReplicaSpecs[Worker].replicas",
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/v2/pkg/controller/mpi_job_controller_status.go
+++ b/v2/pkg/controller/mpi_job_controller_status.go
@@ -46,10 +46,9 @@ func initializeMPIJobStatuses(mpiJob *kubeflow.MPIJob, mtype kubeflow.MPIReplica
 }
 
 // updateMPIJobConditions updates the conditions of the given mpiJob.
-func updateMPIJobConditions(mpiJob *kubeflow.MPIJob, conditionType common.JobConditionType, reason, message string) error {
+func updateMPIJobConditions(mpiJob *kubeflow.MPIJob, conditionType common.JobConditionType, reason, message string) {
 	condition := newCondition(conditionType, reason, message)
 	setCondition(&mpiJob.Status, condition)
-	return nil
 }
 
 // newCondition creates a new mpiJob condition.

--- a/v2/pkg/controller/mpi_job_controller_test.go
+++ b/v2/pkg/controller/mpi_job_controller_test.go
@@ -544,11 +544,10 @@ func TestLauncherSucceeded(t *testing.T) {
 
 	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
 
-	msg := fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
-	err := updateMPIJobConditions(mpiJobCopy, common.JobSucceeded, mpiJobSucceededReason, msg)
-	if err != nil {
-		t.Errorf("Failed to update MPIJob conditions")
-	}
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobCreated, mpiJobCreatedReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobSucceeded, mpiJobSucceededReason, msg)
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
 	f.run(getKey(mpiJob, t))
@@ -579,11 +578,10 @@ func TestLauncherFailed(t *testing.T) {
 	}
 	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
 
-	msg := fmt.Sprintf("MPIJob %s/%s has failed", mpiJob.Namespace, mpiJob.Name)
-	err := updateMPIJobConditions(mpiJobCopy, common.JobFailed, mpiJobFailedReason, msg)
-	if err != nil {
-		t.Errorf("Failed to update MPIJob conditions")
-	}
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobCreated, mpiJobCreatedReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s has failed", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobFailed, mpiJobFailedReason, msg)
 
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
@@ -656,10 +654,7 @@ func TestShutdownWorker(t *testing.T) {
 	var replicas int32 = 8
 	mpiJob := newMPIJob("test", &replicas, 1, gpuResourceName, &startTime, &completionTime)
 	msg := fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
-	err := updateMPIJobConditions(mpiJob, common.JobSucceeded, mpiJobSucceededReason, msg)
-	if err != nil {
-		t.Errorf("Failed to update MPIJob conditions")
-	}
+	updateMPIJobConditions(mpiJob, common.JobSucceeded, mpiJobSucceededReason, msg)
 	f.setUpMPIJob(mpiJob)
 
 	fmjc := f.newFakeMPIJobController()
@@ -759,6 +754,8 @@ func TestLauncherActiveWorkerNotReady(t *testing.T) {
 	}
 	mpiJobCopy := mpiJob.DeepCopy()
 	scheme.Scheme.Default(mpiJobCopy)
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobCreated, mpiJobCreatedReason, msg)
 	mpiJobCopy.Status.ReplicaStatuses = map[common.ReplicaType]*common.ReplicaStatus{
 		common.ReplicaType(kubeflow.MPIReplicaTypeLauncher): {
 			Active:    1,
@@ -825,8 +822,10 @@ func TestLauncherActiveWorkerReady(t *testing.T) {
 		},
 	}
 	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
-	msg := fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
-	err = updateMPIJobConditions(mpiJobCopy, common.JobRunning, mpiJobRunningReason, msg)
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobCreated, mpiJobCreatedReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobRunning, mpiJobRunningReason, msg)
 	if err != nil {
 		t.Errorf("Failed to update MPIJob conditions")
 	}
@@ -882,6 +881,8 @@ func TestWorkerReady(t *testing.T) {
 			Failed:    0,
 		},
 	}
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, common.JobCreated, mpiJobCreatedReason, msg)
 	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 


### PR DESCRIPTION
- Define all fields but the PodTemplateSpec.
- Remove v1alpha1.
- Remove unused API fields from v2beta1 (`mainContainer`, `runPolicy`)

Ensure Pod created condition is applied to the Job copy.