### PR TITLE
Add support for Intel MPI

### DIFF
--- a/examples/pi/intel-entrypoint.sh
+++ b/examples/pi/intel-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set_intel_vars=/opt/intel/oneapi/setvars.sh
+if [ -f $set_intel_vars ]; then
+  source $set_intel_vars
+fi
+
+function resolve_host() {
+  host="$1"
+  check="nslookup $host"
+  max_retry=5
+  counter=0
+  backoff=0.1
+  until $check > /dev/null
+  do
+    if [ $counter -eq $max_retry ]; then
+      echo "Couldn't resolve $host"
+      return
+    fi
+    sleep $backoff
+    echo "Couldn't resolve $host... Retrying"
+    ((counter++))
+    backoff=$(echo - | awk "{print $backoff + $backoff}")
+  done
+  echo "Resolved $host"
+}
+
+if [ "$K_MPI_JOB_ROLE" == "launcher" ]; then
+  resolve_host "$HOSTNAME"
+  cat /etc/mpi/hostfile | while read host
+  do
+    resolve_host $host
+  done
+fi
+
+exec "$@"

--- a/examples/pi/intel.Dockerfile
+++ b/examples/pi/intel.Dockerfile
@@ -1,0 +1,57 @@
+FROM bash AS downloader
+
+RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB -O key.PUB
+
+
+FROM debian:buster as base
+
+COPY --from=downloader key.PUB /tmp/key.PUB
+
+# Install Intel oneAPI keys.
+RUN apt update \
+		&& apt install -y --no-install-recommends gnupg2 ca-certificates \
+    && apt-key add /tmp/key.PUB \
+		&& rm /tmp/key.PUB \
+		&& echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
+		&& apt remove -y gnupg2 ca-certificates \
+		&& apt autoremove -y \
+		&& rm -rf /var/lib/apt/lists/*
+
+
+FROM base as builder
+
+RUN apt update \
+		&& apt install -y --no-install-recommends \
+			libstdc++-8-dev binutils \
+			intel-oneapi-compiler-dpcpp-cpp \
+			intel-oneapi-mpi-devel \
+		&& rm -rf /var/lib/apt/lists/*
+
+ENV I_MPI_CC=clang I_MPI_CXX=clang++
+COPY pi.cc /src/pi.cc
+RUN bash -c "source /opt/intel/oneapi/setvars.sh && mpicxx /src/pi.cc -o /pi"
+
+
+FROM base
+
+RUN apt update \
+		&& apt install -y --no-install-recommends \
+			openssh-server \
+			openssh-client \
+			dnsutils \
+			intel-oneapi-mpi \
+		&& rm -rf /var/lib/apt/lists/*
+
+# Add priviledge separation directoy to run sshd as root.
+RUN mkdir -p /var/run/sshd
+# Add capability to run sshd as non-root.
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/sshd
+
+RUN useradd -m mpiuser
+WORKDIR /home/mpiuser
+COPY intel-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+COPY --chown=mpiuser sshd_config .sshd_config
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config
+
+COPY --from=builder /pi /home/mpiuser/pi

--- a/examples/pi/pi-intel.yaml
+++ b/examples/pi/pi-intel.yaml
@@ -6,19 +6,20 @@ spec:
   slotsPerWorker: 1
   cleanPodPolicy: Running
   sshAuthMountPath: /home/mpiuser/.ssh
+  mpiImplementation: Intel
   mpiReplicaSpecs:
     Launcher:
       replicas: 1
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi
+          - image: docker.io/kubeflow/mpi-pi:intel
+            imagePullPolicy: Always
             name: mpi-launcher
             securityContext:
               runAsUser: 1000
-            command:
-            - mpirun
             args:
+            - mpirun
             - -n
             - "2"
             - /home/mpiuser/pi
@@ -31,7 +32,8 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi
+          - image: docker.io/kubeflow/mpi-pi:intel
+            imagePullPolicy: Always
             name: mpi-worker
             securityContext:
               runAsUser: 1000
@@ -39,8 +41,8 @@ spec:
                 add:
                 - NET_BIND_SERVICE
             command:
-            - /usr/sbin/sshd
             args:
+            - /usr/sbin/sshd
             - -De
             - -f
             - /home/mpiuser/.sshd_config

--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -106,6 +106,9 @@ spec:
                 description: "Defines which Pods must be deleted after the Job completes"
               sshAuthMountPath:
                 type: string
+              mpiImplementation:
+                type: string
+                enum: ["OpenMPI", "Intel"]
               mpiReplicaSpecs:
                 type: object
                 properties:

--- a/v2/pkg/apis/kubeflow/v2beta1/default.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/default.go
@@ -59,6 +59,9 @@ func SetDefaults_MPIJob(mpiJob *MPIJob) {
 	if mpiJob.Spec.SSHAuthMountPath == "" {
 		mpiJob.Spec.SSHAuthMountPath = "/root/.ssh"
 	}
+	if mpiJob.Spec.MPIImplementation == "" {
+		mpiJob.Spec.MPIImplementation = MPIImplementationOpenMPI
+	}
 
 	// set default to Launcher
 	setDefaultsTypeLauncher(mpiJob.Spec.MPIReplicaSpecs[MPIReplicaTypeLauncher])

--- a/v2/pkg/apis/kubeflow/v2beta1/default_test.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/default_test.go
@@ -29,25 +29,28 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 		"base defaults": {
 			want: MPIJob{
 				Spec: MPIJobSpec{
-					SlotsPerWorker:   newInt32(1),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyNone),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(1),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyNone),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: MPIImplementationOpenMPI,
 				},
 			},
 		},
 		"base defaults overridden": {
 			job: MPIJob{
 				Spec: MPIJobSpec{
-					SlotsPerWorker:   newInt32(10),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/home/mpiuser/.ssh",
+					SlotsPerWorker:    newInt32(10),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/home/mpiuser/.ssh",
+					MPIImplementation: MPIImplementationIntel,
 				},
 			},
 			want: MPIJob{
 				Spec: MPIJobSpec{
-					SlotsPerWorker:   newInt32(10),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/home/mpiuser/.ssh",
+					SlotsPerWorker:    newInt32(10),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/home/mpiuser/.ssh",
+					MPIImplementation: MPIImplementationIntel,
 				},
 			},
 		},
@@ -61,9 +64,10 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 			},
 			want: MPIJob{
 				Spec: MPIJobSpec{
-					SlotsPerWorker:   newInt32(1),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyNone),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(1),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyNone),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: MPIImplementationOpenMPI,
 					MPIReplicaSpecs: map[MPIReplicaType]*common.ReplicaSpec{
 						MPIReplicaTypeLauncher: {
 							Replicas:      newInt32(1),
@@ -83,9 +87,10 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 			},
 			want: MPIJob{
 				Spec: MPIJobSpec{
-					SlotsPerWorker:   newInt32(1),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyNone),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(1),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyNone),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: MPIImplementationOpenMPI,
 					MPIReplicaSpecs: map[MPIReplicaType]*common.ReplicaSpec{
 						MPIReplicaTypeWorker: {
 							Replicas:      newInt32(0),

--- a/v2/pkg/apis/kubeflow/v2beta1/types.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/types.go
@@ -55,6 +55,10 @@ type MPIJobSpec struct {
 	// SSHAuthMountPath is the directory where SSH keys are mounted.
 	// Defaults to "/root/.ssh".
 	SSHAuthMountPath string `json:"sshAuthMountPath,omitempty"`
+
+	// MPIImplementation is the MPI implementation.
+	// Options are "OpenMPI" (default) and "Intel".
+	MPIImplementation MPIImplementation `json:"mpiImplementation,omitempty"`
 }
 
 // MPIReplicaType is the type for MPIReplica.
@@ -66,4 +70,11 @@ const (
 
 	// MPIReplicaTypeWorker is the type for worker replicas.
 	MPIReplicaTypeWorker MPIReplicaType = "Worker"
+)
+
+type MPIImplementation string
+
+const (
+	MPIImplementationOpenMPI MPIImplementation = "OpenMPI"
+	MPIImplementationIntel   MPIImplementation = "Intel"
 )

--- a/v2/pkg/apis/kubeflow/validation/validation.go
+++ b/v2/pkg/apis/kubeflow/validation/validation.go
@@ -27,10 +27,16 @@ import (
 	kubeflow "github.com/kubeflow/mpi-operator/v2/pkg/apis/kubeflow/v2beta1"
 )
 
-var validCleanPolicies = sets.NewString(
-	string(common.CleanPodPolicyNone),
-	string(common.CleanPodPolicyRunning),
-	string(common.CleanPodPolicyAll))
+var (
+	validCleanPolicies = sets.NewString(
+		string(common.CleanPodPolicyNone),
+		string(common.CleanPodPolicyRunning),
+		string(common.CleanPodPolicyAll))
+
+	validMPIImplementations = sets.NewString(
+		string(kubeflow.MPIImplementationOpenMPI),
+		string(kubeflow.MPIImplementationIntel))
+)
 
 func ValidateMPIJob(job *kubeflow.MPIJob) field.ErrorList {
 	errs := validateMPIJobName(job)
@@ -67,6 +73,9 @@ func validateMPIJobSpec(spec *kubeflow.MPIJobSpec, path *field.Path) field.Error
 	}
 	if spec.SSHAuthMountPath == "" {
 		errs = append(errs, field.Required(path.Child("sshAuthMountPath"), "must have a mount path for SSH credentials"))
+	}
+	if !validMPIImplementations.Has(string(spec.MPIImplementation)) {
+		errs = append(errs, field.NotSupported(path.Child("mpiImplementation"), spec.MPIImplementation, validMPIImplementations.List()))
 	}
 	return errs
 }

--- a/v2/pkg/apis/kubeflow/validation/validation_test.go
+++ b/v2/pkg/apis/kubeflow/validation/validation_test.go
@@ -37,9 +37,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/home/mpiuser/.ssh",
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/home/mpiuser/.ssh",
+					MPIImplementation: v2beta1.MPIImplementationIntel,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
 							Replicas: newInt32(1),
@@ -59,9 +60,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/home/mpiuser/.ssh",
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/home/mpiuser/.ssh",
+					MPIImplementation: v2beta1.MPIImplementationIntel,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
 							Replicas: newInt32(1),
@@ -105,6 +107,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Type:  field.ErrorTypeRequired,
 					Field: "spec.sshAuthMountPath",
 				},
+				&field.Error{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiImplementation",
+				},
 			},
 		},
 		"invalid fields": {
@@ -113,9 +119,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "this-name-is-waaaaaaaay-too-long-for-a-worker-hostname",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy("unknown"),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy("unknown"),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: v2beta1.MPIImplementation("Unknown"),
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
 							Replicas: newInt32(1),
@@ -145,6 +152,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Type:  field.ErrorTypeNotSupported,
 					Field: "spec.cleanPodPolicy",
 				},
+				{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiImplementation",
+				},
 			},
 		},
 		"empty replica specs": {
@@ -153,10 +164,11 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/root/.ssh",
-					MPIReplicaSpecs:  map[v2beta1.MPIReplicaType]*common.ReplicaSpec{},
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: v2beta1.MPIImplementationOpenMPI,
+					MPIReplicaSpecs:   map[v2beta1.MPIReplicaType]*common.ReplicaSpec{},
 				},
 			},
 			wantErrs: field.ErrorList{
@@ -172,9 +184,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: v2beta1.MPIImplementationOpenMPI,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {},
 						v2beta1.MPIReplicaTypeWorker:   {},
@@ -206,9 +219,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: v2beta1.MPIJobSpec{
-					SlotsPerWorker:   newInt32(2),
-					CleanPodPolicy:   newCleanPodPolicy(common.CleanPodPolicyRunning),
-					SSHAuthMountPath: "/root/.ssh",
+					SlotsPerWorker:    newInt32(2),
+					CleanPodPolicy:    newCleanPodPolicy(common.CleanPodPolicyRunning),
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: v2beta1.MPIImplementationOpenMPI,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
 							Replicas: newInt32(2),


### PR DESCRIPTION
- Adds the field `.spec.mpiImplementation`, defaults to `OpenMPI`
- The Intel implementation requires a Service fronting the launcher
- Passing the number of slots through environment variable instead of hostfile (some versions of Intel MPI ignore the slots defined in the hostfile).
- Add an example that uses Intel MPI

Intel MPI is very flaky at startup, as opposed to OpenMPI. In particular, it won't retry connections to workers if they are the hostnames are not resolvable. The entrypoint handles this.