### PR TITLE
Optimize OpenMPI image size

### DIFF
--- a/examples/pi/Dockerfile
+++ b/examples/pi/Dockerfile
@@ -1,8 +1,17 @@
+FROM debian:buster as builder
+
+RUN apt update && apt install -y --no-install-recommends \
+			g++ \
+			libopenmpi-dev \
+			&& rm -rf /var/lib/apt/lists/*
+
+COPY pi.cc /src/pi.cc
+RUN mpic++ /src/pi.cc -o /pi
+
+
 FROM debian:buster
 
 RUN apt update && apt install -y --no-install-recommends \
-			build-essential \
-			libopenmpi-dev \
 			openmpi-bin \
 			openssh-server \
 			openssh-client \
@@ -16,5 +25,4 @@ RUN useradd -m mpiuser
 WORKDIR /home/mpiuser
 COPY --chown=mpiuser sshd_config .sshd_config
 RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config
-COPY pi.cc /src/pi.cc
-RUN mpic++ /src/pi.cc -o /home/mpiuser/pi
+COPY --from=builder /pi /home/mpiuser/pi


### PR DESCRIPTION
Removing the compiler from the final image.
From 423MB to 184MB