### PR TITLE
Manage launcher through k8s Job

### DIFF
--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -124,7 +124,7 @@ spec:
                         type: object
                       restartPolicy:
                         type: string
-                        enum: ["Never", "OnFailure", "Always"]
+                        enum: ["Never", "OnFailure"]
                   Worker:
                     type: object
                     properties:
@@ -136,7 +136,7 @@ spec:
                         type: object
                       restartPolicy:
                         type: string
-                        enum: ["Never", "OnFailure", "Always"]
+                        enum: ["Never", "OnFailure"]
                 required:
                 - Launcher
           status:

--- a/v2/cmd/mpi-operator/app/server.go
+++ b/v2/cmd/mpi-operator/app/server.go
@@ -157,6 +157,7 @@ func Run(opt *options.ServerOption) error {
 			kubeInformerFactory.Core().V1().ConfigMaps(),
 			kubeInformerFactory.Core().V1().Secrets(),
 			kubeInformerFactory.Core().V1().Services(),
+			kubeInformerFactory.Batch().V1().Jobs(),
 			kubeInformerFactory.Core().V1().Pods(),
 			podgroupsInformer,
 			kubeflowInformerFactory.Kubeflow().V2beta1().MPIJobs(),

--- a/v2/pkg/apis/kubeflow/validation/validation.go
+++ b/v2/pkg/apis/kubeflow/validation/validation.go
@@ -36,6 +36,11 @@ var (
 	validMPIImplementations = sets.NewString(
 		string(kubeflow.MPIImplementationOpenMPI),
 		string(kubeflow.MPIImplementationIntel))
+
+	validRestartPolicies = sets.NewString(
+		string(common.RestartPolicyNever),
+		string(common.RestartPolicyOnFailure),
+	)
 )
 
 func ValidateMPIJob(job *kubeflow.MPIJob) field.ErrorList {
@@ -120,6 +125,9 @@ func validateReplicaSpec(spec *common.ReplicaSpec, path *field.Path) field.Error
 	var errs field.ErrorList
 	if spec.Replicas == nil {
 		errs = append(errs, field.Required(path.Child("replicas"), "must define number of replicas"))
+	}
+	if !validRestartPolicies.Has(string(spec.RestartPolicy)) {
+		errs = append(errs, field.NotSupported(path.Child("restartPolicy"), spec.RestartPolicy, validRestartPolicies.List()))
 	}
 	if len(spec.Template.Spec.Containers) == 0 {
 		errs = append(errs, field.Required(path.Child("template", "spec", "containers"), "must define at least one container"))

--- a/v2/pkg/apis/kubeflow/validation/validation_test.go
+++ b/v2/pkg/apis/kubeflow/validation/validation_test.go
@@ -43,7 +43,8 @@ func TestValidateMPIJob(t *testing.T) {
 					MPIImplementation: v2beta1.MPIImplementationIntel,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
-							Replicas: newInt32(1),
+							Replicas:      newInt32(1),
+							RestartPolicy: common.RestartPolicyNever,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -66,7 +67,8 @@ func TestValidateMPIJob(t *testing.T) {
 					MPIImplementation: v2beta1.MPIImplementationIntel,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
-							Replicas: newInt32(1),
+							Replicas:      newInt32(1),
+							RestartPolicy: common.RestartPolicyOnFailure,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -74,7 +76,8 @@ func TestValidateMPIJob(t *testing.T) {
 							},
 						},
 						v2beta1.MPIReplicaTypeWorker: {
-							Replicas: newInt32(3),
+							Replicas:      newInt32(3),
+							RestartPolicy: common.RestartPolicyNever,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -125,7 +128,8 @@ func TestValidateMPIJob(t *testing.T) {
 					MPIImplementation: v2beta1.MPIImplementation("Unknown"),
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
-							Replicas: newInt32(1),
+							Replicas:      newInt32(1),
+							RestartPolicy: common.RestartPolicyNever,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -133,7 +137,8 @@ func TestValidateMPIJob(t *testing.T) {
 							},
 						},
 						v2beta1.MPIReplicaTypeWorker: {
-							Replicas: newInt32(1000),
+							Replicas:      newInt32(1000),
+							RestartPolicy: common.RestartPolicyNever,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -200,6 +205,10 @@ func TestValidateMPIJob(t *testing.T) {
 					Field: "spec.mpiReplicaSpecs[Launcher].replicas",
 				},
 				{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiReplicaSpecs[Launcher].restartPolicy",
+				},
+				{
 					Type:  field.ErrorTypeRequired,
 					Field: "spec.mpiReplicaSpecs[Launcher].template.spec.containers",
 				},
@@ -208,12 +217,16 @@ func TestValidateMPIJob(t *testing.T) {
 					Field: "spec.mpiReplicaSpecs[Worker].replicas",
 				},
 				{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiReplicaSpecs[Worker].restartPolicy",
+				},
+				{
 					Type:  field.ErrorTypeRequired,
 					Field: "spec.mpiReplicaSpecs[Worker].template.spec.containers",
 				},
 			},
 		},
-		"invalid replica counts": {
+		"invalid replica fields": {
 			job: v2beta1.MPIJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -225,7 +238,8 @@ func TestValidateMPIJob(t *testing.T) {
 					MPIImplementation: v2beta1.MPIImplementationOpenMPI,
 					MPIReplicaSpecs: map[v2beta1.MPIReplicaType]*common.ReplicaSpec{
 						v2beta1.MPIReplicaTypeLauncher: {
-							Replicas: newInt32(2),
+							Replicas:      newInt32(2),
+							RestartPolicy: common.RestartPolicyAlways,
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -233,7 +247,8 @@ func TestValidateMPIJob(t *testing.T) {
 							},
 						},
 						v2beta1.MPIReplicaTypeWorker: {
-							Replicas: newInt32(0),
+							Replicas:      newInt32(0),
+							RestartPolicy: "Invalid",
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{}},
@@ -245,8 +260,16 @@ func TestValidateMPIJob(t *testing.T) {
 			},
 			wantErrs: field.ErrorList{
 				{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiReplicaSpecs[Launcher].restartPolicy",
+				},
+				{
 					Type:  field.ErrorTypeInvalid,
 					Field: "spec.mpiReplicaSpecs[Launcher].replicas",
+				},
+				{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "spec.mpiReplicaSpecs[Worker].restartPolicy",
 				},
 				{
 					Type:  field.ErrorTypeInvalid,

--- a/v2/pkg/controller/mpi_job_controller.go
+++ b/v2/pkg/controller/mpi_job_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/crypto/ssh"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -41,9 +42,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	batchinformers "k8s.io/client-go/informers/batch/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -219,6 +222,8 @@ type MPIJobController struct {
 	secretSynced    cache.InformerSynced
 	serviceLister   corelisters.ServiceLister
 	serviceSynced   cache.InformerSynced
+	jobLister       batchlisters.JobLister
+	jobSynced       cache.InformerSynced
 	podLister       corelisters.PodLister
 	podSynced       cache.InformerSynced
 	podgroupsLister podgroupslists.PodGroupLister
@@ -252,6 +257,7 @@ func NewMPIJobController(
 	configMapInformer coreinformers.ConfigMapInformer,
 	secretInformer coreinformers.SecretInformer,
 	serviceInformer coreinformers.ServiceInformer,
+	jobInformer batchinformers.JobInformer,
 	podInformer coreinformers.PodInformer,
 	podgroupsInformer podgroupsinformer.PodGroupInformer,
 	mpiJobInformer informers.MPIJobInformer,
@@ -281,6 +287,8 @@ func NewMPIJobController(
 		secretSynced:      secretInformer.Informer().HasSynced,
 		serviceLister:     serviceInformer.Lister(),
 		serviceSynced:     serviceInformer.Informer().HasSynced,
+		jobLister:         jobInformer.Lister(),
+		jobSynced:         jobInformer.Informer().HasSynced,
 		podLister:         podInformer.Lister(),
 		podSynced:         podInformer.Informer().HasSynced,
 		podgroupsLister:   podgroupsLister,
@@ -325,6 +333,11 @@ func NewMPIJobController(
 		UpdateFunc: controller.handleObjectUpdate,
 		DeleteFunc: controller.handleObject,
 	})
+	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.handleObject,
+		UpdateFunc: controller.handleObjectUpdate,
+		DeleteFunc: controller.handleObject,
+	})
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleObject,
 		UpdateFunc: controller.handleObjectUpdate,
@@ -353,7 +366,7 @@ func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}) error {
 
 	// Wait for the caches to be synced before starting workers.
 	klog.Info("Waiting for informer caches to sync")
-	if ok := cache.WaitForCacheSync(stopCh, c.configMapSynced, c.secretSynced, c.serviceSynced, c.podSynced, c.mpiJobSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.configMapSynced, c.secretSynced, c.serviceSynced, c.jobSynced, c.podSynced, c.mpiJobSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 	if c.gangSchedulerName != "" {
@@ -486,54 +499,32 @@ func (c *MPIJobController) syncHandler(key string) error {
 		return nil
 	}
 
-	// Whether the job is preempted, and requeue it
-	requeue := false
-	// If the MPIJob is terminated, delete its pods according to cleanPodPolicy.
-	if isFinished(mpiJob.Status) {
-		if isSucceeded(mpiJob.Status) && isCleanUpPods(mpiJob.Spec.CleanPodPolicy) {
-			// set worker StatefulSet Replicas to 0.
-			if err := c.deleteWorkerPods(mpiJob); err != nil {
-				return err
-			}
-			initializeMPIJobStatuses(mpiJob, kubeflow.MPIReplicaTypeWorker)
-			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeWorker)].Active = 0
-			if c.gangSchedulerName != "" {
-				if err := c.deletePodGroups(mpiJob); err != nil {
-					return err
-				}
-			}
-		}
-		if isFailed(mpiJob.Status) {
-			if isEvicted(mpiJob.Status) || mpiJob.Status.CompletionTime == nil {
-				requeue = true
-			}
-		}
-		if !requeue {
-			if isFailed(mpiJob.Status) && isCleanUpPods(mpiJob.Spec.CleanPodPolicy) {
-				// set worker StatefulSet Replicas to 0.
-				if err := c.deleteWorkerPods(mpiJob); err != nil {
-					return err
-				}
-			}
-			return c.updateStatusHandler(mpiJob)
-		} else {
-			launcher, err := c.getLauncherJob(mpiJob)
-			if err == nil && launcher != nil && isPodFailed(launcher) {
-				// In requeue, should delete launcher pod
-				err = c.kubeClient.CoreV1().Pods(launcher.Namespace).Delete(context.TODO(), launcher.Name, metav1.DeleteOptions{})
-				if err != nil && !errors.IsNotFound(err) {
-					klog.Errorf("Failed to delete pod[%s/%s]: %v", mpiJob.Namespace, name, err)
-					return err
-				}
-			}
-		}
-	}
-
 	if len(mpiJob.Status.Conditions) == 0 {
 		msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
 		updateMPIJobConditions(mpiJob, common.JobCreated, mpiJobCreatedReason, msg)
 		c.recorder.Event(mpiJob, corev1.EventTypeNormal, "MPIJobCreated", msg)
 		mpiJobsCreatedCount.Inc()
+	}
+
+	// CompletionTime is only filled when the launcher Job succeeded or stopped
+	// retrying (it reached .spec.backoffLimit). If it's filled, we want to
+	// cleanup and stop retrying the MPIJob.
+	if isFinished(mpiJob.Status) && mpiJob.Status.CompletionTime != nil {
+		if isCleanUpPods(mpiJob.Spec.CleanPodPolicy) {
+			// set worker StatefulSet Replicas to 0.
+			if err := c.deleteWorkerPods(mpiJob); err != nil {
+				return err
+			}
+			initializeMPIJobStatuses(mpiJob, kubeflow.MPIReplicaTypeWorker)
+			if c.gangSchedulerName != "" {
+				if err := c.deletePodGroups(mpiJob); err != nil {
+					return err
+				}
+			}
+			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeWorker)].Active = 0
+			return c.updateStatusHandler(mpiJob)
+		}
+		return nil
 	}
 
 	// first set StartTime.
@@ -550,7 +541,7 @@ func (c *MPIJobController) syncHandler(key string) error {
 
 	var worker []*corev1.Pod
 	// We're done if the launcher either succeeded or failed.
-	done := launcher != nil && isPodFinished(launcher)
+	done := launcher != nil && isJobFinished(launcher)
 	if !done {
 		isGPULauncher := isGPULauncher(mpiJob)
 
@@ -589,7 +580,7 @@ func (c *MPIJobController) syncHandler(key string) error {
 			}
 		}
 		if launcher == nil {
-			launcher, err = c.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), c.newLauncher(mpiJob, isGPULauncher), metav1.CreateOptions{})
+			launcher, err = c.kubeClient.BatchV1().Jobs(namespace).Create(context.TODO(), c.newLauncherJob(mpiJob, isGPULauncher), metav1.CreateOptions{})
 			if err != nil {
 				c.recorder.Eventf(mpiJob, corev1.EventTypeWarning, mpiJobFailedReason, "launcher pod created failed: %v", err)
 				return fmt.Errorf("creating launcher Pod: %w", err)
@@ -608,8 +599,8 @@ func (c *MPIJobController) syncHandler(key string) error {
 }
 
 // getLauncherJob gets the launcher Job controlled by this MPIJob.
-func (c *MPIJobController) getLauncherJob(mpiJob *kubeflow.MPIJob) (*corev1.Pod, error) {
-	launcher, err := c.podLister.Pods(mpiJob.Namespace).Get(mpiJob.Name + launcherSuffix)
+func (c *MPIJobController) getLauncherJob(mpiJob *kubeflow.MPIJob) (*batchv1.Job, error) {
+	launcher, err := c.jobLister.Jobs(mpiJob.Namespace).Get(mpiJob.Name + launcherSuffix)
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -890,7 +881,7 @@ func (c *MPIJobController) deleteWorkerPods(mpiJob *kubeflow.MPIJob) error {
 		name := fmt.Sprintf("%s-%d", workerPrefix, i)
 		pod, err := c.podLister.Pods(mpiJob.Namespace).Get(name)
 
-		// If the worker Pod doesn't exist, we'll create it.
+		// If the worker Pod doesn't exist, no need to remove it.
 		if errors.IsNotFound(err) {
 			continue
 		}
@@ -918,38 +909,42 @@ func (c *MPIJobController) deleteWorkerPods(mpiJob *kubeflow.MPIJob) error {
 	return nil
 }
 
-func (c *MPIJobController) updateMPIJobStatus(mpiJob *kubeflow.MPIJob, launcher *corev1.Pod, worker []*corev1.Pod) error {
+func (c *MPIJobController) updateMPIJobStatus(mpiJob *kubeflow.MPIJob, launcher *batchv1.Job, worker []*corev1.Pod) error {
 	oldStatus := mpiJob.Status.DeepCopy()
+	// Job.status.Active accounts for Pending and Running pods. Querying
+	// the pods to get only the Running pods.
+	launcherPodsCnt, err := c.jobRunningPodsCount(launcher)
+	if err != nil {
+		return fmt.Errorf("checking launcher pods running: %w", err)
+	}
 	if launcher != nil {
 		initializeMPIJobStatuses(mpiJob, kubeflow.MPIReplicaTypeLauncher)
-		if isPodSucceeded(launcher) {
-			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeLauncher)].Succeeded = 1
+		launcherStatus := mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeLauncher)]
+		launcherStatus.Failed = launcher.Status.Failed
+		if isJobSucceeded(launcher) {
+			launcherStatus.Succeeded = 1
 			msg := fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
 			c.recorder.Event(mpiJob, corev1.EventTypeNormal, mpiJobSucceededReason, msg)
 			if mpiJob.Status.CompletionTime == nil {
-				now := metav1.Now()
-				mpiJob.Status.CompletionTime = &now
+				mpiJob.Status.CompletionTime = launcher.Status.CompletionTime
 			}
 			updateMPIJobConditions(mpiJob, common.JobSucceeded, mpiJobSucceededReason, msg)
 			mpiJobsSuccessCount.Inc()
-		} else if isPodFailed(launcher) {
-			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeLauncher)].Failed = 1
+		} else if isJobFailed(launcher) {
 			msg := fmt.Sprintf("MPIJob %s/%s has failed", mpiJob.Namespace, mpiJob.Name)
-			reason := launcher.Status.Reason
+			reason := getJobCondition(launcher, batchv1.JobFailed).Reason
 			if reason == "" {
 				reason = mpiJobFailedReason
 			}
 			c.recorder.Event(mpiJob, corev1.EventTypeWarning, reason, msg)
-			if reason == "Evicted" {
-				reason = mpiJobEvict
-			} else if !isEvicted(mpiJob.Status) && mpiJob.Status.CompletionTime == nil {
+			if mpiJob.Status.CompletionTime == nil {
 				now := metav1.Now()
 				mpiJob.Status.CompletionTime = &now
 			}
 			updateMPIJobConditions(mpiJob, common.JobFailed, reason, msg)
 			mpiJobsFailureCount.Inc()
-		} else if isPodRunning(launcher) {
-			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeLauncher)].Active = 1
+		} else {
+			mpiJob.Status.ReplicaStatuses[common.ReplicaType(kubeflow.MPIReplicaTypeLauncher)].Active = int32(launcherPodsCnt)
 		}
 		mpiJobInfoGauge.WithLabelValues(launcher.Name, mpiJob.Namespace).Set(1)
 	}
@@ -982,7 +977,7 @@ func (c *MPIJobController) updateMPIJobStatus(mpiJob *kubeflow.MPIJob, launcher 
 		c.recorder.Event(mpiJob, corev1.EventTypeWarning, mpiJobEvict, msg)
 	}
 
-	if launcher != nil && launcher.Status.Phase == corev1.PodRunning && running == len(worker) {
+	if launcher != nil && launcherPodsCnt >= 1 && running == len(worker) {
 		msg := fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
 		updateMPIJobConditions(mpiJob, common.JobRunning, mpiJobRunningReason, msg)
 		c.recorder.Eventf(mpiJob, corev1.EventTypeNormal, "MPIJobRunning", "MPIJob %s/%s is running", mpiJob.Namespace, mpiJob.Name)
@@ -1039,29 +1034,39 @@ func (c *MPIJobController) handleObject(obj interface{}) {
 		klog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
 	klog.V(4).Infof("Processing object: %s", object.GetName())
-	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
-		// Parse the Group out of the OwnerReference to compare it to what was parsed out of the requested OwnerType
-		refGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
-		if err != nil {
-			runtime.HandleError(fmt.Errorf("Could not parse OwnerReference APIVersion: %v", err))
-			return
-		}
-
-		// Compare the OwnerReference Group and Kind against the OwnerType Group and Kind.
-		// Since we do not support conversion webhook now, we do not deal with v1alpha1 resources in this operator.
-		if ownerRef.Kind != kubeflow.Kind || refGV.Group != kubeflow.GroupName || refGV.Version != kubeflow.GroupVersion {
-			return
-		}
-
-		mpiJob, err := c.mpiJobLister.MPIJobs(object.GetNamespace()).Get(ownerRef.Name)
-		if err != nil {
-			klog.V(4).Infof("ignoring orphaned object '%s' of mpi job '%s'", object.GetSelfLink(), ownerRef.Name)
-			return
-		}
-
-		c.enqueueMPIJob(mpiJob)
+	ownerRef, ownerGVK, err := ownerReferenceAndGVK(object)
+	if err != nil {
+		runtime.HandleError(err)
 		return
 	}
+
+	// If the Pod is controlled by a Job, get the Job's ownerReference.
+	if ownerGVK.Group == batchv1.GroupName && ownerGVK.Kind == "Job" {
+		j, err := c.jobLister.Jobs(object.GetNamespace()).Get(ownerRef.Name)
+		if err != nil {
+			runtime.HandleError(fmt.Errorf("obtaining owning k8s Job: %w", err))
+			return
+		}
+		ownerRef, ownerGVK, err = ownerReferenceAndGVK(j)
+		if err != nil {
+			runtime.HandleError(fmt.Errorf("obtaining k8s Job's owner: %w", err))
+			return
+		}
+	}
+
+	// Compare the OwnerReference Group and Kind against the OwnerType Group and Kind.
+	// Since we do not support conversion webhook now, we do not deal with v1alpha1/v1alpha2/v1 resources in this operator.
+	if ownerGVK.Kind != kubeflow.Kind || ownerGVK.Group != kubeflow.GroupName || ownerGVK.Version != kubeflow.GroupVersion {
+		return
+	}
+
+	mpiJob, err := c.mpiJobLister.MPIJobs(object.GetNamespace()).Get(ownerRef.Name)
+	if err != nil {
+		klog.V(4).Infof("ignoring orphaned object '%s' of mpi job '%s'", object.GetSelfLink(), ownerRef.Name)
+		return
+	}
+
+	c.enqueueMPIJob(mpiJob)
 }
 
 func (c *MPIJobController) handleObjectUpdate(old, new interface{}) {
@@ -1290,10 +1295,28 @@ func (c *MPIJobController) newWorker(mpiJob *kubeflow.MPIJob, index int) *corev1
 	}
 }
 
-// newLauncher creates a new launcher Job for an MPIJob resource. It also sets
+func (c *MPIJobController) newLauncherJob(mpiJob *kubeflow.MPIJob, isGPULauncher bool) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mpiJob.Name + launcherSuffix,
+			Namespace: mpiJob.Namespace,
+			Labels: map[string]string{
+				"app": mpiJob.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(mpiJob, kubeflow.SchemeGroupVersionKind),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: c.newLauncherPodTemplate(mpiJob, isGPULauncher),
+		},
+	}
+}
+
+// newLauncherPodTemplate creates a new launcher Job for an MPIJob resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the MPIJob resource that 'owns' it.
-func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, isGPULauncher bool) *corev1.Pod {
+func (c *MPIJobController) newLauncherPodTemplate(mpiJob *kubeflow.MPIJob, isGPULauncher bool) corev1.PodTemplateSpec {
 	launcherName := mpiJob.Name + launcherSuffix
 
 	podTemplate := mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.DeepCopy()
@@ -1372,10 +1395,8 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, isGPULauncher bo
 		MountPath: configMountPath,
 	})
 
-	return &corev1.Pod{
+	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        launcherName,
-			Namespace:   mpiJob.Namespace,
 			Labels:      podTemplate.Labels,
 			Annotations: podTemplate.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
@@ -1386,6 +1407,24 @@ func (c *MPIJobController) newLauncher(mpiJob *kubeflow.MPIJob, isGPULauncher bo
 	}
 }
 
+func (c *MPIJobController) jobRunningPodsCount(j *batchv1.Job) (int, error) {
+	selector, err := metav1.LabelSelectorAsSelector(j.Spec.Selector)
+	if err != nil {
+		return 0, fmt.Errorf("parsing Pod selector: %w", err)
+	}
+	pods, err := c.podLister.Pods(j.Namespace).List(selector)
+	if err != nil {
+		return 0, fmt.Errorf("obtaining pods: %w", err)
+	}
+	running := 0
+	for _, p := range pods {
+		if metav1.IsControlledBy(p, j) && isPodRunning(p) {
+			running++
+		}
+	}
+	return running, nil
+}
+
 func setRestartPolicy(podTemplateSpec *corev1.PodTemplateSpec, spec *common.ReplicaSpec) {
 	if spec.RestartPolicy == common.RestartPolicyExitCode {
 		podTemplateSpec.Spec.RestartPolicy = v1.RestartPolicyNever
@@ -1394,16 +1433,27 @@ func setRestartPolicy(podTemplateSpec *corev1.PodTemplateSpec, spec *common.Repl
 	}
 }
 
-func isPodFinished(j *corev1.Pod) bool {
-	return isPodSucceeded(j) || isPodFailed(j)
+func isJobFinished(j *batchv1.Job) bool {
+	return isJobSucceeded(j) || isJobFailed(j)
 }
 
-func isPodFailed(p *corev1.Pod) bool {
-	return p.Status.Phase == corev1.PodFailed
+func isJobFailed(j *batchv1.Job) bool {
+	c := getJobCondition(j, batchv1.JobFailed)
+	return c != nil && c.Status == corev1.ConditionTrue
 }
 
-func isPodSucceeded(p *corev1.Pod) bool {
-	return p.Status.Phase == corev1.PodSucceeded
+func isJobSucceeded(j *batchv1.Job) bool {
+	c := getJobCondition(j, batchv1.JobComplete)
+	return c != nil && c.Status == corev1.ConditionTrue
+}
+
+func getJobCondition(j *batchv1.Job, condition batchv1.JobConditionType) *batchv1.JobCondition {
+	for _, c := range j.Status.Conditions {
+		if c.Type == condition {
+			return &c
+		}
+	}
+	return nil
 }
 
 func isPodRunning(p *corev1.Pod) bool {
@@ -1509,6 +1559,18 @@ func (c *MPIJobController) setupSSHOnPod(podSpec *corev1.PodSpec, job *kubeflow.
 		Command: []string{"/bin/sh"},
 		Args:    []string{"-c", initScript},
 	})
+}
+
+func ownerReferenceAndGVK(object metav1.Object) (*metav1.OwnerReference, schema.GroupVersionKind, error) {
+	ownerRef := metav1.GetControllerOf(object)
+	if ownerRef == nil {
+		return nil, schema.GroupVersionKind{}, nil
+	}
+	gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+	if err != nil {
+		return nil, schema.GroupVersionKind{}, fmt.Errorf("parsing owner's API version: %w", err)
+	}
+	return ownerRef, gv.WithKind(ownerRef.Kind), nil
 }
 
 func newInt32(v int32) *int32 {


### PR DESCRIPTION
Part of #386 

- Ensure restart policy is `Never` or `OnFailure`.
- Manage launcher through k8s Job
  - Still tracking Running status of the job pods.
  - Removed launcher Pod recreation logic, as this is now handled by the k8s Job controller
- Pending (for followup PRs):
  - Expose fields for controlling retries and timeout in MPIJob API.
  - Ensure that worker pods are recreated when failed.