### PR TITLE
Add support for using existing ServiceAccount for Launcher pod (#394)

### DIFF
--- a/cmd/mpi-operator.v1alpha2/app/options/options.go
+++ b/cmd/mpi-operator.v1alpha2/app/options/options.go
@@ -23,15 +23,16 @@ import (
 
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
-	Kubeconfig           string
-	MasterURL            string
-	KubectlDeliveryImage string
-	Threadiness          int
-	MonitoringPort       int
-	PrintVersion         bool
-	GangSchedulingName   string
-	Namespace            string
-	LockNamespace        string
+	Kubeconfig                       string
+	MasterURL                        string
+	KubectlDeliveryImage             string
+	Threadiness                      int
+	MonitoringPort                   int
+	PrintVersion                     bool
+	GangSchedulingName               string
+	Namespace                        string
+	LockNamespace                    string
+	UseLauncherPodSpecServiceAccount bool
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -67,4 +68,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.GangSchedulingName, "gang-scheduling", "", "Set gang scheduler name if enable gang scheduling.")
 
 	fs.StringVar(&s.LockNamespace, "lock-namespace", "mpi-operator", "Set locked namespace name while enabling leader election.")
+
+	fs.BoolVar(&s.UseLauncherPodSpecServiceAccount, "use-launcher-pod-spec-serviceaccount", false, "Set Launcher ServiceAccount based on the Launcher pod spec. When enabled, role and rolebinding won't be created")
 }

--- a/cmd/mpi-operator.v1alpha2/app/server.go
+++ b/cmd/mpi-operator.v1alpha2/app/server.go
@@ -160,7 +160,8 @@ func Run(opt *options.ServerOption) error {
 			podgroupsInformer,
 			kubeflowInformerFactory.Kubeflow().V1alpha2().MPIJobs(),
 			opt.KubectlDeliveryImage,
-			opt.GangSchedulingName)
+			opt.GangSchedulingName,
+			opt.UseLauncherPodSpecServiceAccount)
 
 		go kubeInformerFactory.Start(ctx.Done())
 		go kubeflowInformerFactory.Start(ctx.Done())

--- a/pkg/controllers/v1alpha2/mpi_job_controller_test.go
+++ b/pkg/controllers/v1alpha2/mpi_job_controller_test.go
@@ -177,6 +177,7 @@ func (f *fixture) newController(gangSchedulerName string) (*MPIJobController, in
 		i.Kubeflow().V1alpha2().MPIJobs(),
 		"kubectl-delivery",
 		gangSchedulerName,
+		false,
 	)
 
 	c.configMapSynced = alwaysReady


### PR DESCRIPTION
Add support for using existing ServiceAccount for Launcher pod (#394)

* Do not create a SA, Role and RoleBinding when --use-launcher-pod-spec-serviceaccount=true,
  instead, use SA configured in spec.mpiReplicaSpecs.Launcher.template.spec.serviceAccountName