### PR TITLE
E2E test for v2 controller

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,17 @@ jobs:
         run: make mpi-operator.v1alpha1 mpi-operator.v1alpha2 mpi-operator.v1 mpi-operator.v2 kubectl-delivery
       - name: Run tests
         run: make test
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+    - name: Clone the code
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.15'
+    - name: Run tests
+      run: make RELEASE_VERSION=test CONTROLLER_VERSION=v2 test_e2e

--- a/examples/pi/pi-intel.yaml
+++ b/examples/pi/pi-intel.yaml
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi:intel
+          - image: kubeflow/mpi-pi:intel
             imagePullPolicy: Always
             name: mpi-launcher
             securityContext:
@@ -32,7 +32,7 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi:intel
+          - image: kubeflow/mpi-pi:intel
             imagePullPolicy: Always
             name: mpi-worker
             securityContext:

--- a/examples/pi/pi.cc
+++ b/examples/pi/pi.cc
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
   std::uniform_real_distribution<double> distribution(-1.0, 1.0);
   double x, y;
   long long worker_count = 0;
-  int worker_tests = 100000000;
+  int worker_tests = 10000000;
   for (int i = 0; i < worker_tests; i++) {
     x = distribution(generator);
     y = distribution(generator);

--- a/examples/pi/pi.yaml
+++ b/examples/pi/pi.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi
+          - image: kubeflow/mpi-pi
             name: mpi-launcher
             securityContext:
               runAsUser: 1000
@@ -31,7 +31,7 @@ spec:
       template:
         spec:
           containers:
-          - image: docker.io/kubeflow/mpi-pi
+          - image: kubeflow/mpi-pi
             name: mpi-worker
             securityContext:
               runAsUser: 1000

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -20,6 +20,5 @@ spec:
         - --lock-namespace
         - $(lock-namespace)
         image: mpioperator/mpi-operator:latest
-        imagePullPolicy: Always
         name: mpi-operator
       serviceAccountName: mpi-operator

--- a/manifests/overlays/dev/.gitignore
+++ b/manifests/overlays/dev/.gitignore
@@ -1,0 +1,1 @@
+kustomization.yaml

--- a/manifests/overlays/dev/kustomization.yaml.template
+++ b/manifests/overlays/dev/kustomization.yaml.template
@@ -11,8 +11,8 @@ commonLabels:
   app.kubernetes.io/component: mpijob
 images:
 - name: mpioperator/mpi-operator
-  newName: dev-registry/mpi-operator
-  newTag: latest
+  newName: %IMAGE_NAME%
+  newTag: %IMAGE_TAG%
 configMapGenerator:
 - name: mpi-operator-config
   envs:

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/go-openapi/spec v0.19.3
 	github.com/google/go-cmp v0.5.6
 	github.com/kubeflow/common v0.3.4
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.7.1
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	k8s.io/api v0.19.9

--- a/v2/test/e2e/e2e_suite_test.go
+++ b/v2/test/e2e/e2e_suite_test.go
@@ -1,0 +1,157 @@
+// Copyright 2021 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+
+	clientset "github.com/kubeflow/mpi-operator/v2/pkg/client/clientset/versioned"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	envUseExistingCluster   = "USE_EXISTING_CLUSTER"
+	envTestMPIOperatorImage = "TEST_MPI_OPERATOR_IMAGE"
+	envTestKindImage        = "TEST_KIND_IMAGE"
+
+	defaultMPIOperatorImage = "kubeflow/mpi-operator:local"
+	defaultKindImage        = "kindest/node:v1.21.2"
+	openMPIImage            = "kubeflow/mpi-pi:openmpi"
+	rootPath                = "../../.."
+	kubectlPath             = rootPath + "/bin/kubectl"
+	operatorManifestsPath   = rootPath + "/manifests/overlays/dev"
+
+	mpiOperator = "mpi-operator"
+
+	waitInterval   = 500 * time.Millisecond
+	foreverTimeout = 100 * time.Second
+)
+
+var (
+	useExistingCluster bool
+	kindPath           string
+	mpiOperatorImage   string
+	kindImage          string
+
+	k8sClient kubernetes.Interface
+	mpiClient clientset.Interface
+)
+
+func init() {
+	useExistingCluster = getEnvDefault(envUseExistingCluster, "false") == "true"
+	mpiOperatorImage = getEnvDefault(envTestMPIOperatorImage, defaultMPIOperatorImage)
+	kindImage = getEnvDefault(envTestKindImage, defaultKindImage)
+	kindPath = "kind"
+	if goPath := os.Getenv("GOPATH"); goPath != "" {
+		kindPath = path.Join(goPath, "bin", "kind")
+	}
+}
+
+func TestE2E(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "E2e Suite")
+}
+
+var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+	if !useExistingCluster {
+		ginkgo.By("Creating a local cluster")
+		err := bootstrapKindCluster()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+	ginkgo.By("Obtaining clients")
+	restConfig, err := controllerruntime.GetConfig()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	k8sClient, err = kubernetes.NewForConfig(restConfig)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	mpiClient, err = clientset.NewForConfig(restConfig)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	ginkgo.By("Installing operator")
+	err = installOperator()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	return nil
+}, func([]byte) {})
+
+var _ = ginkgo.SynchronizedAfterSuite(func() {
+	if !useExistingCluster {
+		ginkgo.By("Deleting local cluster")
+		err := runCommand(kindPath, "delete", "cluster")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	} else {
+		ginkgo.By("Uninstalling operator")
+		err := runCommand(kubectlPath, "delete", "-k", operatorManifestsPath)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+}, func() {})
+
+func getEnvDefault(key, defaultVal string) string {
+	v, ok := os.LookupEnv(key)
+	if ok {
+		return v
+	}
+	return defaultVal
+}
+
+func bootstrapKindCluster() error {
+	err := runCommand(kindPath, "create", "cluster", "--image", kindImage)
+	if err != nil {
+		return fmt.Errorf("creating kind cluster: %w", err)
+	}
+	err = runCommand(kindPath, "load", "docker-image", mpiOperatorImage, openMPIImage)
+	if err != nil {
+		return fmt.Errorf("loading container images: %w", err)
+	}
+	return nil
+}
+
+func installOperator() error {
+	err := runCommand(kubectlPath, "apply", "-k", operatorManifestsPath)
+	if err != nil {
+		return fmt.Errorf("applying operator YAMLs: %w", err)
+	}
+	ctx := context.Background()
+	return wait.Poll(waitInterval, foreverTimeout, func() (bool, error) {
+		deployment, err := k8sClient.AppsV1().Deployments(mpiOperator).Get(ctx, mpiOperator, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return deployment.Status.AvailableReplicas != 0, nil
+	})
+}
+
+func runCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}

--- a/v2/test/e2e/mpi_job_test.go
+++ b/v2/test/e2e/mpi_job_test.go
@@ -1,0 +1,154 @@
+// Copyright 2021 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	common "github.com/kubeflow/common/pkg/apis/common/v1"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kubeflow "github.com/kubeflow/mpi-operator/v2/pkg/apis/kubeflow/v2beta1"
+)
+
+var _ = ginkgo.Describe("MPIJob", func() {
+	var (
+		namespace string
+		mpiJob    *kubeflow.MPIJob
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-",
+			},
+		}
+		var err error
+		ns, err = k8sClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		namespace = ns.Name
+	})
+
+	ginkgo.AfterEach(func() {
+		if namespace != "" {
+			err := k8sClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+			if !errors.IsNotFound(err) {
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		}
+	})
+
+	ginkgo.BeforeEach(func() {
+		mpiJob = &kubeflow.MPIJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pi",
+				Namespace: namespace,
+			},
+			Spec: kubeflow.MPIJobSpec{
+				MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*common.ReplicaSpec{
+					kubeflow.MPIReplicaTypeLauncher: {},
+					kubeflow.MPIReplicaTypeWorker: {
+						Replicas: newInt32(2),
+					},
+				},
+			},
+		}
+	})
+
+	ginkgo.Context("with OpenMPI implementation", func() {
+
+		ginkgo.BeforeEach(func() {
+			mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    "launcher",
+					Image:   openMPIImage,
+					Command: []string{"mpirun"},
+					Args: []string{
+						"-n",
+						"2",
+						"/home/mpiuser/pi",
+					},
+				},
+			}
+			mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.Containers = []corev1.Container{
+				{
+					Name:  "worker",
+					Image: openMPIImage,
+				},
+			}
+		})
+
+		ginkgo.Context("when running as non-root user", func() {
+
+			ginkgo.BeforeEach(func() {
+				mpiJob.Spec.SSHAuthMountPath = "/home/mpiuser/.ssh"
+				mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+					RunAsUser: newInt64(1000),
+				}
+				workerContainer := &mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.Containers[0]
+				workerContainer.SecurityContext = &corev1.SecurityContext{
+					RunAsUser: newInt64(1000),
+					Capabilities: &corev1.Capabilities{
+						Add: []corev1.Capability{"NET_BIND_SERVICE"},
+					},
+				}
+				workerContainer.Command = []string{"/usr/sbin/sshd"}
+				workerContainer.Args = []string{"-De", "-f", "/home/mpiuser/.sshd_config"}
+			})
+
+			ginkgo.It("should succeed", func() {
+				ctx := context.Background()
+				var err error
+				ginkgo.By("Creating MPIJob")
+				mpiJob, err = mpiClient.KubeflowV2beta1().MPIJobs(namespace).Create(ctx, mpiJob, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				ginkgo.By("Waiting for MPIJob to finish")
+				err = wait.Poll(waitInterval, foreverTimeout, func() (bool, error) {
+					updatedJob, err := mpiClient.KubeflowV2beta1().MPIJobs(namespace).Get(ctx, mpiJob.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, err
+					}
+					mpiJob = updatedJob
+					return mpiJob.Status.CompletionTime != nil, nil
+				})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				var succeedCond *common.JobCondition
+				for _, cond := range mpiJob.Status.Conditions {
+					if cond.Type == common.JobSucceeded {
+						succeedCond = &cond
+						break
+					}
+				}
+				gomega.Expect(succeedCond).ToNot(gomega.BeNil())
+				gomega.Expect(succeedCond.Status).To(gomega.Equal(corev1.ConditionTrue))
+			})
+		})
+	})
+})
+
+func newInt32(v int32) *int32 {
+	return &v
+}
+
+func newInt64(v int64) *int64 {
+	return &v
+}


### PR DESCRIPTION
Part of #373. Related to #296 

Add first E2E test for the v2 controller: Tests that an OpenMPI sample runs to completion as non-root user.

The tests run locally on a [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) cluster.

The tests run as a new workflow job.

**Notes to reviewer**

Other tests combinations (IntelMPI, run-as-root) coming in follow up PRs.