### PR TITLE
Fix intel MPI E2E test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ images:
 
 .PHONY: test_images
 test_images:
-	${IMG_BUILDER} build -t kubeflow/mpi-pi:openmpi examples/pi
+	${IMG_BUILDER} build -t mpioperator/mpi-pi:openmpi examples/pi
+	${IMG_BUILDER} build -t mpioperator/mpi-pi:intel examples/pi -f examples/pi/intel.Dockerfile
 
 .PHONY: tidy
 tidy:

--- a/examples/pi/intel-entrypoint.sh
+++ b/examples/pi/intel-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 function resolve_host() {
   host="$1"
   check="nslookup $host"
-  max_retry=5
+  max_retry=10
   counter=0
   backoff=0.1
   until $check > /dev/null

--- a/v2/test/e2e/e2e_suite_test.go
+++ b/v2/test/e2e/e2e_suite_test.go
@@ -43,7 +43,8 @@ const (
 
 	defaultMPIOperatorImage = "kubeflow/mpi-operator:local"
 	defaultKindImage        = "kindest/node:v1.21.2"
-	openMPIImage            = "kubeflow/mpi-pi:openmpi"
+	openMPIImage            = "mpioperator/mpi-pi:openmpi"
+	intelMPIImage           = "mpioperator/mpi-pi:intel"
 	rootPath                = "../../.."
 	kubectlPath             = rootPath + "/bin/kubectl"
 	operatorManifestsPath   = rootPath + "/manifests/overlays/dev"
@@ -131,7 +132,7 @@ func bootstrapKindCluster() error {
 	if err != nil {
 		return fmt.Errorf("creating kind cluster: %w", err)
 	}
-	err = runCommand(kindPath, "load", "docker-image", mpiOperatorImage, openMPIImage)
+	err = runCommand(kindPath, "load", "docker-image", mpiOperatorImage, openMPIImage, intelMPIImage)
 	if err != nil {
 		return fmt.Errorf("loading container images: %w", err)
 	}


### PR DESCRIPTION
And print last launcher and workers logs when E2E test fails.

More notes on Intel:
The Intel MPI framework doesn't do retries on startup, when the network is still being set up. To increase the chances of success, I increased the number of nslookups before starting up the launcher, and configured the Job to only have 1 worker.