### PR TITLE
Set OnFailure default restart policy for launcher

### DIFF
--- a/v2/pkg/apis/kubeflow/v2beta1/constants.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/constants.go
@@ -21,6 +21,8 @@ const (
 	EnvKubeflowNamespace = "KUBEFLOW_NAMESPACE"
 	// DefaultRestartPolicy is default RestartPolicy for ReplicaSpec.
 	DefaultRestartPolicy = common.RestartPolicyNever
+	// Launcher will fail on start if workers DNS names are not ready so we set OnFailure restart policy
+	DefaultLauncherRestartPolicy = common.RestartPolicyOnFailure
 	// OperatorName is the name of the operator used as value to the label common.OperatorLabelName
 	OperatorName = "mpi-operator"
 )

--- a/v2/pkg/apis/kubeflow/v2beta1/constants.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/constants.go
@@ -21,7 +21,7 @@ const (
 	EnvKubeflowNamespace = "KUBEFLOW_NAMESPACE"
 	// DefaultRestartPolicy is default RestartPolicy for ReplicaSpec.
 	DefaultRestartPolicy = common.RestartPolicyNever
-	// Launcher will fail on start if workers DNS names are not ready so we set OnFailure restart policy
+	// DefaultLauncherRestartPolicy is default RestartPolicy for Launcher Job.
 	DefaultLauncherRestartPolicy = common.RestartPolicyOnFailure
 	// OperatorName is the name of the operator used as value to the label common.OperatorLabelName
 	OperatorName = "mpi-operator"

--- a/v2/pkg/apis/kubeflow/v2beta1/default.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/default.go
@@ -29,7 +29,7 @@ func setDefaultsTypeLauncher(spec *common.ReplicaSpec) {
 		return
 	}
 	if spec.RestartPolicy == "" {
-		spec.RestartPolicy = DefaultRestartPolicy
+		spec.RestartPolicy = DefaultLauncherRestartPolicy
 	}
 	if spec.Replicas == nil {
 		spec.Replicas = newInt32(1)

--- a/v2/pkg/apis/kubeflow/v2beta1/default_test.go
+++ b/v2/pkg/apis/kubeflow/v2beta1/default_test.go
@@ -85,7 +85,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 					MPIReplicaSpecs: map[MPIReplicaType]*common.ReplicaSpec{
 						MPIReplicaTypeLauncher: {
 							Replicas:      newInt32(1),
-							RestartPolicy: DefaultRestartPolicy,
+							RestartPolicy: DefaultLauncherRestartPolicy,
 						},
 					},
 				},

--- a/v2/pkg/controller/mpi_job_controller_test.go
+++ b/v2/pkg/controller/mpi_job_controller_test.go
@@ -1001,7 +1001,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Hostname:      "foo-launcher",
 							Subdomain:     "foo-worker",
-							RestartPolicy: corev1.RestartPolicyNever,
+							RestartPolicy: corev1.RestartPolicyOnFailure,
 							Containers: []corev1.Container{
 								{
 									Env: joinEnvVars(


### PR DESCRIPTION
Change Launger restart policy from Newer to OnFailure to mitigate initial DNS lookup errors.