### PR TITLE
Add readiness probe to Intel MPI jobs

### DIFF
--- a/examples/pi/pi-intel.yaml
+++ b/examples/pi/pi-intel.yaml
@@ -47,6 +47,10 @@ spec:
             - -De
             - -f
             - /home/mpiuser/.sshd_config
+            readinessProbe:
+              tcpSocket:
+                port: 22
+              initialDelaySeconds: 2
             resources:
               limits:
                 cpu: 1


### PR DESCRIPTION
This improves the reliability of MPI Jobs.

The readiness probe ensures that sshd is up and running before the hostname is resolvable.