### PR TITLE
Support read permissions for clusterRole and write permissions for mu…

### DIFF
--- a/cmd/mpi-operator.v1/app/options/options.go
+++ b/cmd/mpi-operator.v1/app/options/options.go
@@ -24,6 +24,7 @@ import (
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
 	Kubeconfig           string
+	KubeconfigRorWrite   string
 	MasterURL            string
 	KubectlDeliveryImage string
 	Threadiness          int
@@ -50,6 +51,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(&s.Kubeconfig, "kubeConfig", "",
 		"Path to a kubeConfig. Only required if out-of-cluster.")
+	fs.StringVar(&s.KubeconfigRorWrite, "kubeconfig-for-write", "", "kubeconfig for write(create/delete) permission.")
 
 	fs.StringVar(&s.KubectlDeliveryImage, "kubectl-delivery-image", "",
 		"The container image used to deliver the kubectl binary.")


### PR DESCRIPTION
In a multi-user shared kubernetes cluster, it is difficult to provide cluster-level write permissions to mpi-operator, but it is necessary for mpi-operator to dynamically support the ability to create mpijobs in multiple namespaces.
Therefore, mpi operaetor needs to support cluster-level read permissions (get/list/watch) and multiple namespace-level write permissions.
When adding a new namespace, you need to create mpijobs, you can create Role and Rolebindng in the corresponding namespace.