### PR TITLE
Add namespace and `svc` suffix for host configmap

### DIFF
--- a/v2/pkg/controller/mpi_job_controller.go
+++ b/v2/pkg/controller/mpi_job_controller.go
@@ -1107,7 +1107,7 @@ func newConfigMap(mpiJob *kubeflow.MPIJob, workerReplicas int32) *corev1.ConfigM
 	var buffer bytes.Buffer
 	workersService := mpiJob.Name + workerSuffix
 	for i := 0; i < int(workerReplicas); i++ {
-		buffer.WriteString(fmt.Sprintf("%s%s-%d.%s\n", mpiJob.Name, workerSuffix, i, workersService))
+        buffer.WriteString(fmt.Sprintf("%s%s-%d.%s.%s.svc\n", mpiJob.Name, workerSuffix, i, workersService, mpiJob.Namespace))
 	}
 
 	return &corev1.ConfigMap{
@@ -1138,7 +1138,7 @@ func updateDiscoverHostsInConfigMap(configMap *corev1.ConfigMap, mpiJob *kubeflo
 	buffer.WriteString("#!/bin/sh\n")
 	workersService := mpiJob.Name + workerSuffix
 	for _, p := range runningPods {
-		buffer.WriteString(fmt.Sprintf("echo %s.%s\n", p.Name, workersService))
+        buffer.WriteString(fmt.Sprintf("echo %s.%s.%s.svc\n", p.Name, workersService, p.Namespace))
 	}
 
 	configMap.Data[discoverHostsScriptName] = buffer.String()

--- a/v2/pkg/controller/mpi_job_controller.go
+++ b/v2/pkg/controller/mpi_job_controller.go
@@ -1107,7 +1107,7 @@ func newConfigMap(mpiJob *kubeflow.MPIJob, workerReplicas int32) *corev1.ConfigM
 	var buffer bytes.Buffer
 	workersService := mpiJob.Name + workerSuffix
 	for i := 0; i < int(workerReplicas); i++ {
-        buffer.WriteString(fmt.Sprintf("%s%s-%d.%s.%s.svc\n", mpiJob.Name, workerSuffix, i, workersService, mpiJob.Namespace))
+		buffer.WriteString(fmt.Sprintf("%s%s-%d.%s.%s.svc\n", mpiJob.Name, workerSuffix, i, workersService, mpiJob.Namespace))
 	}
 
 	return &corev1.ConfigMap{
@@ -1138,7 +1138,7 @@ func updateDiscoverHostsInConfigMap(configMap *corev1.ConfigMap, mpiJob *kubeflo
 	buffer.WriteString("#!/bin/sh\n")
 	workersService := mpiJob.Name + workerSuffix
 	for _, p := range runningPods {
-        buffer.WriteString(fmt.Sprintf("echo %s.%s.%s.svc\n", p.Name, workersService, p.Namespace))
+		buffer.WriteString(fmt.Sprintf("echo %s.%s.%s.svc\n", p.Name, workersService, p.Namespace))
 	}
 
 	configMap.Data[discoverHostsScriptName] = buffer.String()


### PR DESCRIPTION
This is follow up to issue: https://github.com/kubeflow/mpi-operator/issues/453

Quoted here:
```
In the v2 implementation, headless worker service is referenced by `jobname-worker-0.jobname-worker` (https://github.com/alculquicondor/mpi-operator/blob/master/v2/pkg/controller/mpi_job_controller.go#L1110)  which requires the pod `/etc/resolv.conf` config having `namespace.svc.cluster.local` presented.

The `tf-operator` on the other side composes TFCONFIG with both namespace and `svc` suffix: https://github.com/kubeflow/training-operator/blob/master/pkg/controller.v1/tensorflow/tensorflow.go#L159

Is it possible to consolidate the logic so that the same cluster DNS settings work for both operators? 
```