### PR TITLE
Add setup info for Python SDK

### DIFF
--- a/sdk/python/v1/README.md
+++ b/sdk/python/v1/README.md
@@ -17,9 +17,9 @@ Python 2.7 and 3.4+
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
+pip install git+https://github.com/kubeflow/mpi-operator.git#subdirectory=sdk/python/v1
 ```
-(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
+(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/kubeflow/mpi-operator.git#subdirectory=sdk/python/v1`)
 
 Then import the package:
 ```python

--- a/sdk/python/v1/setup.py
+++ b/sdk/python/v1/setup.py
@@ -12,5 +12,24 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "kubeflow"
-VERSION = "0.1"
+with open('requirements.txt') as f:
+    REQUIRES = f.readlines()
+
+with open('test-requirements.txt') as f:
+    TEST_REQUIRES = f.readlines()
+
+setup(
+	name='kubeflow-mpijob',
+  	version='0.1.0',
+	author="Kubeflow Authors",
+	url="https://github.com/kubeflow/mpi-operator/sdk/python/v1",
+	description="MPI Operator Python SDK V1",
+	long_description="MPI Operator Python SDK V1",
+	packages=find_packages(include=("mpijob*")),
+	package_data={},
+	include_package_data=False,
+	zip_safe=False,
+	install_requires=REQUIRES,
+	tests_require=TEST_REQUIRES,
+	extras_require={'test': TEST_REQUIRES}
+)

--- a/sdk/python/v2beta1/README.md
+++ b/sdk/python/v2beta1/README.md
@@ -17,9 +17,9 @@ Python 2.7 and 3.4+
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
+pip install git+https://github.com/kubeflow/mpi-operator.git#subdirectory=sdk/python/v2beta1
 ```
-(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
+(you may need to run `pip` with root permission: `sudo pip install git+https://github.com/kubeflow/mpi-operator.git#subdirectory=sdk/python/v2beta1`)
 
 Then import the package:
 ```python

--- a/sdk/python/v2beta1/setup.py
+++ b/sdk/python/v2beta1/setup.py
@@ -12,5 +12,24 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "kubeflow"
-VERSION = "0.1"
+with open('requirements.txt') as f:
+    REQUIRES = f.readlines()
+
+with open('test-requirements.txt') as f:
+    TEST_REQUIRES = f.readlines()
+
+setup(
+	name='kubeflow-mpijob',
+  	version='0.2.0',
+	author="Kubeflow Authors",
+	url="https://github.com/kubeflow/mpi-operator/sdk/python/v2beta1",
+	description="MPI Operator Python SDK V2",
+	long_description="MPI Operator Python SDK V2",
+	packages=find_packages(include=("mpijob*")),
+	package_data={},
+	include_package_data=False,
+	zip_safe=False,
+	install_requires=REQUIRES,
+	tests_require=TEST_REQUIRES,
+	extras_require={'test': TEST_REQUIRES}
+)


### PR DESCRIPTION
This change enables easy command line pip installation for the Python SDK v1 & v2beta1, e.g 
```
pip install git+https://github.com/kubeflow/mpi-operator.git#subdirectory=sdk/python/v2beta1
```

Ideally the package should be published to Pypi but skip it for now since `mpi-operator` v2 will eventually merged into `training-operator` and Python SDK is already maintained in the other repo (https://github.com/kubeflow/training-operator/issues/1380).