### PR TITLE
Adding mpi-operator workflow to release multi-arch docker image

### DIFF
--- a/.github/workflows/mpi-operator-docker-image-publish.yml
+++ b/.github/workflows/mpi-operator-docker-image-publish.yml
@@ -1,0 +1,55 @@
+name: build and publish mpi multi-arch docker image
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "master"
+
+env:
+  IMAGE_NAME: mpioperator/mpi-operator
+
+jobs:
+  build-push-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Adding new workflow "mpi-operator-docker-image-publish.yml" to release multi-arch docker image for linux amd64, ppc64le and arm64 
*  Following the existing versioning  convention to tag the docker images
*  using qemu and buildx  to build multi-arch docker image 


please set the following secrets at repo level from github UI:

DOCKERHUB_USERNAME
DOCKERHUB_TOKEN 

if using github cli, run the following:
gh secret set DOCKERHUB_USERNAME -b 'docker_username' -R Kubeflow/mpi-operator 
gh secret set DOCKERHUB_TOKEN -b 'docker_token' -R Kubeflow/mpi-operator 

Please review and merge.
