### PR TITLE
Fix lint errors

### DIFF
--- a/pkg/controllers/kubectl_delivery/controller_test.go
+++ b/pkg/controllers/kubectl_delivery/controller_test.go
@@ -15,7 +15,6 @@
 package kubectl_delivery
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -94,7 +93,7 @@ func TestGeneratingHostsFile(t *testing.T) {
 		t.Errorf("Error, cannot generating hosts of worker pods, errs: %v", err)
 	}
 	// get the output file content
-	outputContent, err := ioutil.ReadFile(tmpof)
+	outputContent, err := os.ReadFile(tmpof)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controllers/kubectl_delivery/utils_test.go
+++ b/pkg/controllers/kubectl_delivery/utils_test.go
@@ -17,7 +17,6 @@ package kubectl_delivery
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -143,12 +142,12 @@ func (f *fixture) getResolvedHosts(contentBytes []byte) map[string]string {
 // setUpTmpDir will create a temp directory and create a temp hosts file
 // with provided file content, and return the path of the directory.
 func (f *fixture) setUpTmpDir(dirName string, content []byte) (string, string) {
-	p, err := ioutil.TempDir(os.TempDir(), "hosts")
+	p, err := os.MkdirTemp(os.TempDir(), "hosts")
 	if err != nil {
 		f.t.Fatal(err)
 	}
 	tmphf := filepath.Join(p, "hosts")
-	if err := ioutil.WriteFile(tmphf, content, 0644); err != nil {
+	if err := os.WriteFile(tmphf, content, 0644); err != nil {
 		f.t.Fatal(err)
 	}
 	return p, tmphf


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

I fixed lint errors in the following:

https://github.com/kubeflow/mpi-operator/actions/runs/3855667972/jobs/6570962124#step:3:78

```shell
run golangci-lint
  Running [/home/runner/golangci-lint-1.50.1-linux-amd64/golangci-lint run --out-format=github-actions --timeout=5m] in [] ...
  Error: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (staticcheck)
  Error: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (staticcheck)
  
  Error: issues found
  Ran golangci-lint in 1214ms
```