### PR TITLE
Remove the openapi-generator-cli.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _output/
 bin/
 profile.cov
+hack/python-sdk/openapi-generator-cli.jar


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

I removed `hack/python-sdk/openapi-generator-cli.jar` and added it to .gitignore.

Fixes: #498 