### PR TITLE
Validate MPIJob name with the DNS 1035 label

### DIFF
--- a/pkg/apis/kubeflow/validation/validation.go
+++ b/pkg/apis/kubeflow/validation/validation.go
@@ -58,8 +58,8 @@ func validateMPIJobName(job *kubeflow.MPIJob) field.ErrorList {
 		}
 	}
 	maximumPodHostname := fmt.Sprintf("%s-worker-%d", job.Name, replicas-1)
-	if errs := apimachineryvalidation.IsDNS1123Label(maximumPodHostname); len(errs) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), job.ObjectMeta.Name, fmt.Sprintf("will not able to create pod with invalid DNS label %q: %s", maximumPodHostname, strings.Join(errs, ", "))))
+	if errs := apimachineryvalidation.IsDNS1035Label(maximumPodHostname); len(errs) > 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), job.ObjectMeta.Name, fmt.Sprintf("will not able to create pod and service with invalid DNS label %q: %s", maximumPodHostname, strings.Join(errs, ", "))))
 	}
 	return allErrs
 }

--- a/pkg/apis/kubeflow/validation/validation_test.go
+++ b/pkg/apis/kubeflow/validation/validation_test.go
@@ -304,6 +304,36 @@ func TestValidateMPIJob(t *testing.T) {
 				},
 			},
 		},
+		"invalid mpiJob name": {
+			job: kubeflow.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "1-foo",
+				},
+				Spec: kubeflow.MPIJobSpec{
+					SlotsPerWorker: newInt32(2),
+					RunPolicy: kubeflow.RunPolicy{
+						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+					},
+					SSHAuthMountPath:  "/home/mpiuser/.ssh",
+					MPIImplementation: kubeflow.MPIImplementationIntel,
+					MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*common.ReplicaSpec{
+						kubeflow.MPIReplicaTypeLauncher: {
+							Replicas:      newInt32(1),
+							RestartPolicy: common.RestartPolicyNever,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErrs: field.ErrorList{{
+				Type:  field.ErrorTypeInvalid,
+				Field: "metadata.name",
+			}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

Currently, we validate the MPIJob name with DNS 1123 Label. However, the K8s Service name must meet DNS 1035 label.

https://github.com/kubernetes/kubernetes/blob/0e3818e02760afa8ed0bea74c6973f605ca4683c/pkg/apis/core/validation/validation.go#L248-L251

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names

So, I changed the validator for the MPIJob name to `IsDNS1035Label`.
