### PR TITLE
Remove unnecessary permissions

### DIFF
--- a/deploy/v2beta1/mpi-operator.yaml
+++ b/deploy/v2beta1/mpi-operator.yaml
@@ -8194,15 +8194,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - list
-  - update
-  - watch
-- apiGroups:
   - batch
   resources:
   - jobs

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -51,15 +51,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - list
-  - update
-  - watch
-- apiGroups:
   - batch
   resources:
   - jobs


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

I removed unnecessary permissions since mpi-operator v2 does not use StatefulSet.

