### PR TITLE
Run the CodeQL for push events only when pushing to the master branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: codescanning
 
 on:
   push:
+    branches: [master]
   pull_request:
   schedule:
     #        ┌───────────── minute (0 - 59)


### PR DESCRIPTION
According to the following error message, the CodeQL requires to write access. However, since Dependabot doesn't have write access, we need to restrict push events except for pushing to the master branch.

> Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

https://github.com/kubeflow/mpi-operator/actions/runs/4209565634/jobs/7306556611#step:11:47

Blocking: #525 

/assign @alculquicondor 
