### PR TITLE
Stop using e2e tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet:
 .PHONY: test
 test:
 test: bin/envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -covermode atomic -coverprofile=profile.cov ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -covermode atomic -coverprofile=profile.cov $(shell go list ./... | grep -v '/test/e2e')
 
 # Only works with CONTROLLER_VERSION=v2
 .PHONY: test_e2e

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: bin/envtest
 .PHONY: test_e2e
 test_e2e: export TEST_MPI_OPERATOR_IMAGE = ${IMAGE_NAME}:${RELEASE_VERSION}
 test_e2e: bin/kubectl kind images test_images dev_manifest
-	go test -tags e2e ./test/e2e/...
+	go test -v ./test/e2e/...
 
 .PHONY: dev_manifest
 dev_manifest:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (

--- a/test/e2e/mpi_job_test.go
+++ b/test/e2e/mpi_job_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e
-// +build e2e
-
 package e2e
 
 import (


### PR DESCRIPTION
If we add build tags to e2e test codes, `go fmt` and `go vet` ignores those files. So I removed the e2e tag so that we could format those codes.

Ref: https://github.com/golang/go/issues/4007
