### PR TITLE
Stop using the kustomize vars feature

### DIFF
--- a/deploy/v2beta1/mpi-operator.yaml
+++ b/deploy/v2beta1/mpi-operator.yaml
@@ -8269,19 +8269,6 @@ subjects:
   name: mpi-operator
   namespace: mpi-operator
 ---
-apiVersion: v1
-data:
-  lock-namespace: mpi-operator
-kind: ConfigMap
-metadata:
-  labels:
-    app: mpi-operator
-    app.kubernetes.io/component: mpijob
-    app.kubernetes.io/name: mpi-operator
-    kustomize.component: mpi-operator
-  name: mpi-operator-config
-  namespace: mpi-operator
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8313,8 +8300,7 @@ spec:
       containers:
       - args:
         - -alsologtostderr
-        - --lock-namespace
-        - mpi-operator
+        - --lock-namespace=mpi-operator
         image: mpioperator/mpi-operator:master
         name: mpi-operator
       serviceAccountName: mpi-operator

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -17,8 +17,6 @@ spec:
       containers:
       - args:
         - -alsologtostderr
-        - --lock-namespace
-        - $(lock-namespace)
         image: mpioperator/mpi-operator:latest
         name: mpi-operator
       serviceAccountName: mpi-operator

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -16,17 +16,3 @@ images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
   newTag: latest
-configMapGenerator:
-- name: mpi-operator-config
-  envs:
-  - params.env
-generatorOptions:
-  disableNameSuffixHash: true
-vars:
-- name: lock-namespace
-  objref:
-    kind: ConfigMap
-    name: mpi-operator-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.lock-namespace

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -1,1 +1,0 @@
-lock-namespace=kubeflow

--- a/manifests/overlays/dev/kustomization.yaml.template
+++ b/manifests/overlays/dev/kustomization.yaml.template
@@ -13,8 +13,10 @@ images:
 - name: mpioperator/mpi-operator
   newName: %IMAGE_NAME%
   newTag: %IMAGE_TAG%
-configMapGenerator:
-- name: mpi-operator-config
-  envs:
-  - params.env
-  behavior: merge
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: mpi-operator
+  path: ./patch.yaml

--- a/manifests/overlays/dev/params.env
+++ b/manifests/overlays/dev/params.env
@@ -1,1 +1,0 @@
-lock-namespace=mpi-operator

--- a/manifests/overlays/dev/patch.yaml
+++ b/manifests/overlays/dev/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--lock-namespace=mpi-operator"

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -8,3 +8,10 @@ commonLabels:
   app: mpi-operator
   app.kubernetes.io/name: mpi-operator
   app.kubernetes.io/component: mpijob
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: mpi-operator
+    path: ./patch.yaml

--- a/manifests/overlays/kubeflow/patch.yaml
+++ b/manifests/overlays/kubeflow/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--lock-namespace=kubeflow"

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -13,8 +13,10 @@ images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
   newTag: master
-configMapGenerator:
-- name: mpi-operator-config
-  envs:
-  - params.env
-  behavior: merge
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: mpi-operator
+    path: ./patch.yaml

--- a/manifests/overlays/standalone/params.env
+++ b/manifests/overlays/standalone/params.env
@@ -1,1 +1,0 @@
-lock-namespace=mpi-operator

--- a/manifests/overlays/standalone/patch.yaml
+++ b/manifests/overlays/standalone/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--lock-namespace=mpi-operator"


### PR DESCRIPTION
Since kustomize v5, the `vars` feature has been deprecated. So I replaced the `vars` with the kustomize patch.

> The vars field was deprecated in v5.0.0. This field will never be removed from the kustomize.config.k8s.io/v1beta1 Kustomization API, but it will not be included in the kustomize.config.k8s.io/v1 Kustomization API. When Kustomization v1 is available, we will announce the deprecation of the v1beta1 version. There will be at least two releases between deprecation and removal of Kustomization v1beta1 support from the kustomize CLI, and removal itself will happen in a future major version bump.

https://github.com/kubernetes-sigs/cli-experimental/blob/7b72bd123ddad23c20bfc6607a039a08717b6934/site/content/en/references/kustomize/kustomization/vars/_index.md