### PR TITLE
Add tenzen-y as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 approvers:
+  - alculquicondor
   - rongou
   - terrytangyuan
-  - alculquicondor
 reviewers:
   - carmark
   - gaocegege
+  - tenzen-y
   - zw0610


### PR DESCRIPTION
I self-nominate as a reviewer.

- [22 merged PRs](https://github.com/kubeflow/mpi-operator/pulls?q=is%3Apr+is%3Aclosed+author%3Atenzen-y+merged%3A%3C%3D2023-02-28)

Also, I sorted the OWERS file according to alphabetic.

/assign @alculquicondor @terrytangyuan @kubeflow/wg-training-leads
/hold
