### PR TITLE
Implement E2E for integration with scheduler-plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 profile.cov
 hack/python-sdk/openapi-generator-cli.jar
 dep-crds/
+dep-manifests/


### PR DESCRIPTION
I implemented E2E for integrating with scheduler-plugins.

Part-of: #500 

~~NOTE: This test will still fail since I forgot to implement the logic to update PodGroup when mpiJob.spec.runPolicy.schedulingPolicy is updated.~~
~~So we must implement the logic first in another PR.~~

resolved in: #542