### PR TITLE
Add written permission to the dep-manifests dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,3 +183,4 @@ scheduler-plugins-chart: scheduler-plugins-crd
 	cp -f /tmp/pkg/mod/sigs.k8s.io/scheduler-plugins@$(SCHEDULER_PLUGINS_VERSION)/manifests/capacityscheduling/crd.yaml $(PROJECT_DIR)/dep-manifests/scheduler-plugins/crds/scheduling.x-k8s.io_elasticquotas.yaml
 	cp -f $(PROJECT_DIR)/dep-crds/scheduler-plugins/crd.yaml $(PROJECT_DIR)/dep-manifests/scheduler-plugins/crds/scheduling.x-k8s.io_podgroups.yaml
 	cp -f /tmp/pkg/mod/sigs.k8s.io/scheduler-plugins@$(SCHEDULER_PLUGINS_VERSION)/manifests/noderesourcetopology/crd.yaml $(PROJECT_DIR)/dep-manifests/scheduler-plugins/crds/topology.node.k8s.io_noderesourcetopologies.yaml
+	chmod -R 760 $(PROJECT_DIR)/dep-manifests/scheduler-plugins


### PR DESCRIPTION
It seems that the scheduler-plugins Charts have only read permission. So we must add written permission to that.

Before:

```shell
$ ll -a dep-manifests/scheduler-plugins/
total 24
drwxr-xr-x  7 tenzen-y  1796141739   224 Apr  6 01:44 ./
drwxr-xr-x  3 tenzen-y  1796141739    96 Apr  6 01:44 ../
-r--r--r--  1 tenzen-y  1796141739  1138 Apr  6 01:44 Chart.yaml
-r--r--r--  1 tenzen-y  1796141739  3171 Apr  6 01:44 README.md
drwxr-xr-x  7 tenzen-y  1796141739   224 Apr  6 01:44 crds/
dr-xr-xr-x  7 tenzen-y  1796141739   224 Apr  6 01:44 templates/
-r--r--r--  1 tenzen-y  1796141739  1237 Apr  6 01:44 values.yaml
```

After:

```shell
ll -a dep-manifests/scheduler-plugins/
total 24
drwxrw----  7 tenzen-y  1796141739   224 Apr  6 01:46 ./
drwxr-xr-x  3 tenzen-y  1796141739    96 Apr  6 01:46 ../
-rwxrw----  1 tenzen-y  1796141739  1138 Apr  6 01:46 Chart.yaml*
-rwxrw----  1 tenzen-y  1796141739  3171 Apr  6 01:46 README.md*
drwxrw----  7 tenzen-y  1796141739   224 Apr  6 01:46 crds/
drwxrw----  7 tenzen-y  1796141739   224 Apr  6 01:46 templates/
-rwxrw----  1 tenzen-y  1796141739  1237 Apr  6 01:46 values.yaml*
```

Fixes: #546
