### PR TITLE
Replace https://bootstrap.pypa.io/get-pip.py with https://bootstrap.pypa.io/pip/3.6/get-pip.py in horovod example Dockerfile

### DIFF
--- a/examples/v2beta1/horovod/Dockerfile
+++ b/examples/v2beta1/horovod/Dockerfile
@@ -35,7 +35,7 @@ RUN if [[ "${PYTHON_VERSION}" == "3.6" ]]; then \
     fi
 RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
+RUN curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 


### PR DESCRIPTION
Build horovod container image fails due to the below error. This PR pin `get-pip.py` to Python 3.6.

```bash
docker build -t horovod:latest .
...
Step 14/24 : RUN curl -O https://bootstrap.pypa.io/get-pip.py &&     python get-pip.py &&     rm get-pip.py
 ---> Running in 3d66f554398e
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2518k  100 2518k    0     0  2125k      0  0:00:01  0:00:01 --:--:-- 2125k
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
The command '/bin/bash -cu curl -O https://bootstrap.pypa.io/get-pip.py &&     python get-pip.py &&     rm get-pip.py' returned a non-zero code: 1
```

