### PR TITLE
Run E2E with various kubernetes versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: ["v1.25.8", "v1.26.3", "v1.27.1"]
     steps:
     - name: Clone the code
       uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KUBEBUILDER_ASSETS_PATH := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))bin/ku
 KIND_VERSION=v0.18.0
 HELM_VERSION=v3.11.2
 # This kubectl version supports -k for kustomization.
-KUBECTL_VERSION=v1.25.6
+KUBECTL_VERSION=v1.25.8
 ENVTEST_K8S_VERSION=1.25.0
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 GOARCH=$(shell go env GOARCH)


### PR DESCRIPTION
I modified the configuration file for actions to verify the mpi-operator run on various kubernetes versions.
