### PR TITLE
Commonize function newCleanPodPolicy()

### DIFF
--- a/pkg/apis/kubeflow/v2beta1/default.go
+++ b/pkg/apis/kubeflow/v2beta1/default.go
@@ -51,7 +51,7 @@ func setDefaultsTypeWorker(spec *common.ReplicaSpec) {
 
 func setDefaultsRunPolicy(policy *RunPolicy) {
 	if policy.CleanPodPolicy == nil {
-		policy.CleanPodPolicy = newCleanPodPolicy(CleanPodPolicyNone)
+		policy.CleanPodPolicy = NewCleanPodPolicy(CleanPodPolicyNone)
 	}
 	// The remaining fields are passed as-is to the k8s Job API, which does its
 	// own defaulting.
@@ -80,6 +80,6 @@ func newInt32(v int32) *int32 {
 	return &v
 }
 
-func newCleanPodPolicy(policy CleanPodPolicy) *CleanPodPolicy {
+func NewCleanPodPolicy(policy CleanPodPolicy) *CleanPodPolicy {
 	return &policy
 }

--- a/pkg/apis/kubeflow/v2beta1/default_test.go
+++ b/pkg/apis/kubeflow/v2beta1/default_test.go
@@ -31,7 +31,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 				Spec: MPIJobSpec{
 					SlotsPerWorker: newInt32(1),
 					RunPolicy: RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(CleanPodPolicyNone),
+						CleanPodPolicy: NewCleanPodPolicy(CleanPodPolicyNone),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: MPIImplementationOpenMPI,
@@ -43,7 +43,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 				Spec: MPIJobSpec{
 					SlotsPerWorker: newInt32(10),
 					RunPolicy: RunPolicy{
-						CleanPodPolicy:          newCleanPodPolicy(CleanPodPolicyRunning),
+						CleanPodPolicy:          NewCleanPodPolicy(CleanPodPolicyRunning),
 						TTLSecondsAfterFinished: newInt32(2),
 						ActiveDeadlineSeconds:   newInt64(3),
 						BackoffLimit:            newInt32(4),
@@ -56,7 +56,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 				Spec: MPIJobSpec{
 					SlotsPerWorker: newInt32(10),
 					RunPolicy: RunPolicy{
-						CleanPodPolicy:          newCleanPodPolicy(CleanPodPolicyRunning),
+						CleanPodPolicy:          NewCleanPodPolicy(CleanPodPolicyRunning),
 						TTLSecondsAfterFinished: newInt32(2),
 						ActiveDeadlineSeconds:   newInt64(3),
 						BackoffLimit:            newInt32(4),
@@ -78,7 +78,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 				Spec: MPIJobSpec{
 					SlotsPerWorker: newInt32(1),
 					RunPolicy: RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(CleanPodPolicyNone),
+						CleanPodPolicy: NewCleanPodPolicy(CleanPodPolicyNone),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: MPIImplementationOpenMPI,
@@ -103,7 +103,7 @@ func TestSetDefaults_MPIJob(t *testing.T) {
 				Spec: MPIJobSpec{
 					SlotsPerWorker: newInt32(1),
 					RunPolicy: RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(CleanPodPolicyNone),
+						CleanPodPolicy: NewCleanPodPolicy(CleanPodPolicyNone),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: MPIImplementationOpenMPI,

--- a/pkg/apis/kubeflow/validation/validation_test.go
+++ b/pkg/apis/kubeflow/validation/validation_test.go
@@ -39,7 +39,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/home/mpiuser/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationIntel,
@@ -65,7 +65,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/home/mpiuser/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationIntel,
@@ -128,7 +128,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy:          newCleanPodPolicy("unknown"),
+						CleanPodPolicy:          kubeflow.NewCleanPodPolicy("unknown"),
 						TTLSecondsAfterFinished: newInt32(-1),
 						ActiveDeadlineSeconds:   newInt64(-1),
 						BackoffLimit:            newInt32(-1),
@@ -192,7 +192,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationOpenMPI,
@@ -214,7 +214,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationOpenMPI,
@@ -259,7 +259,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/root/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationOpenMPI,
@@ -312,7 +312,7 @@ func TestValidateMPIJob(t *testing.T) {
 				Spec: kubeflow.MPIJobSpec{
 					SlotsPerWorker: newInt32(2),
 					RunPolicy: kubeflow.RunPolicy{
-						CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+						CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 					},
 					SSHAuthMountPath:  "/home/mpiuser/.ssh",
 					MPIImplementation: kubeflow.MPIImplementationIntel,
@@ -350,9 +350,5 @@ func newInt32(v int32) *int32 {
 }
 
 func newInt64(v int64) *int64 {
-	return &v
-}
-
-func newCleanPodPolicy(v kubeflow.CleanPodPolicy) *kubeflow.CleanPodPolicy {
 	return &v
 }

--- a/test/integration/mpi_job_controller_test.go
+++ b/test/integration/mpi_job_controller_test.go
@@ -63,7 +63,7 @@ func TestMPIJobSuccess(t *testing.T) {
 		Spec: kubeflow.MPIJobSpec{
 			SlotsPerWorker: newInt32(1),
 			RunPolicy: kubeflow.RunPolicy{
-				CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+				CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 			},
 			MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*common.ReplicaSpec{
 				kubeflow.MPIReplicaTypeLauncher: {
@@ -189,7 +189,7 @@ func TestMPIJobResumingAndSuspending(t *testing.T) {
 		Spec: kubeflow.MPIJobSpec{
 			SlotsPerWorker: newInt32(1),
 			RunPolicy: kubeflow.RunPolicy{
-				CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+				CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 				Suspend:        pointer.Bool(true),
 			},
 			MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*common.ReplicaSpec{
@@ -353,7 +353,7 @@ func TestMPIJobFailure(t *testing.T) {
 		Spec: kubeflow.MPIJobSpec{
 			SlotsPerWorker: newInt32(1),
 			RunPolicy: kubeflow.RunPolicy{
-				CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+				CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 			},
 			MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*common.ReplicaSpec{
 				kubeflow.MPIReplicaTypeLauncher: {
@@ -481,7 +481,7 @@ func TestMPIJobWithSchedulerPlugins(t *testing.T) {
 		Spec: kubeflow.MPIJobSpec{
 			SlotsPerWorker: newInt32(1),
 			RunPolicy: kubeflow.RunPolicy{
-				CleanPodPolicy: newCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
+				CleanPodPolicy: kubeflow.NewCleanPodPolicy(kubeflow.CleanPodPolicyRunning),
 				SchedulingPolicy: &kubeflow.SchedulingPolicy{
 					ScheduleTimeoutSeconds: pointer.Int32(900),
 				},
@@ -885,10 +885,6 @@ func isJobSuspended(job *batchv1.Job) bool {
 
 func newInt32(v int32) *int32 {
 	return &v
-}
-
-func newCleanPodPolicy(policy kubeflow.CleanPodPolicy) *kubeflow.CleanPodPolicy {
-	return &policy
 }
 
 func eventForJob(event corev1.Event, job *kubeflow.MPIJob) corev1.Event {


### PR DESCRIPTION
Currently, we have duplicated functions to create a pointer for the `CleanPodPolicy` .
That situation could be more efficient. So I commonized the function `newCleanPodPolicy()`.
