### PR TITLE
Bumping controller-gen to fix unknown field error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ helm: bin
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: bin
-	@GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1
+	@GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
 
 KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
 .PHONY: kustomize

--- a/deploy/v2beta1/mpi-operator.yaml
+++ b/deploy/v2beta1/mpi-operator.yaml
@@ -21,8 +21,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     app: mpi-operator
     app.kubernetes.io/component: mpijob

--- a/manifests/base/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/kubeflow.org_mpijobs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: mpijobs.kubeflow.org
 spec:
   group: kubeflow.org


### PR DESCRIPTION
I upgraded the controller-gen to fix an unknown field error.

```shell
W0601 09:22:34.369203   30031 warnings.go:70] unknown field "spec.mpiReplicaSpecs.Launcher.template.metadata.creationTimestamp"
```

xref: https://github.com/kubernetes-sigs/controller-tools/issues/402
