### PR TITLE
Fix a bug that the PodGroupCtrl can not list priorityclass

### DIFF
--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeinformers "k8s.io/client-go/informers"
-	schedulinginformers "k8s.io/client-go/informers/scheduling/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -45,7 +44,6 @@ import (
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	volcanofake "volcano.sh/apis/pkg/client/clientset/versioned/fake"
 
-	"github.com/kubeflow/mpi-operator/cmd/mpi-operator/app/options"
 	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	"github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/fake"
 	"github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/scheme"
@@ -164,29 +162,21 @@ func (f *fixture) newController(clock clock.WithTicker) (*MPIJobController, info
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeClient, noResyncPeriodFunc())
 
-	var (
-		podGroupCtrl          PodGroupControl
-		priorityClassInformer schedulinginformers.PriorityClassInformer
-	)
-	if f.gangSchedulingName == options.GangSchedulerVolcano {
-		podGroupCtrl = NewVolcanoCtrl(f.volcanoClient, metav1.NamespaceAll)
-	} else if len(f.gangSchedulingName) != 0 {
-		priorityClassInformer = k8sI.Scheduling().V1().PriorityClasses()
-		podGroupCtrl = NewSchedulerPluginsCtrl(f.schedClient, metav1.NamespaceAll, "default-scheduler", priorityClassInformer.Lister())
-	}
-
 	c := NewMPIJobControllerWithClock(
 		f.kubeClient,
 		f.client,
-		podGroupCtrl,
+		f.volcanoClient,
+		f.schedClient,
 		k8sI.Core().V1().ConfigMaps(),
 		k8sI.Core().V1().Secrets(),
 		k8sI.Core().V1().Services(),
 		k8sI.Batch().V1().Jobs(),
 		k8sI.Core().V1().Pods(),
-		priorityClassInformer,
+		k8sI.Scheduling().V1().PriorityClasses(),
 		i.Kubeflow().V2beta1().MPIJobs(),
 		clock,
+		metav1.NamespaceAll,
+		f.gangSchedulingName,
 	)
 
 	c.configMapSynced = alwaysReady
@@ -232,15 +222,15 @@ func (f *fixture) newController(clock clock.WithTicker) (*MPIJobController, info
 		}
 	}
 
-	if podGroupCtrl != nil {
+	if c.PodGroupCtrl != nil {
 		for _, podGroup := range f.volcanoPodGroupLister {
-			err := podGroupCtrl.PodGroupSharedIndexInformer().GetIndexer().Add(podGroup)
+			err := c.PodGroupCtrl.PodGroupSharedIndexInformer().GetIndexer().Add(podGroup)
 			if err != nil {
 				fmt.Println("Failed to create volcano pod group")
 			}
 		}
 		for _, podGroup := range f.schedPodGroupLister {
-			err := podGroupCtrl.PodGroupSharedIndexInformer().GetIndexer().Add(podGroup)
+			err := c.PodGroupCtrl.PodGroupSharedIndexInformer().GetIndexer().Add(podGroup)
 			if err != nil {
 				fmt.Println("Failed to create scheduler-plugins pod group")
 			}
@@ -282,8 +272,8 @@ func (f *fixture) runController(mpiJobName string, startInformers, expectError b
 		defer close(stopCh)
 		i.Start(stopCh)
 		k8sI.Start(stopCh)
-		if c.podGroupCtrl != nil {
-			c.podGroupCtrl.StartInformerFactory(stopCh)
+		if c.PodGroupCtrl != nil {
+			c.PodGroupCtrl.StartInformerFactory(stopCh)
 		}
 	}
 

--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -231,6 +231,10 @@ func (s *SchedulerPluginsCtrl) newPodGroup(mpiJob *kubeflow.MPIJob) metav1.Objec
 		scheduleTimeoutSec = schedPolicy.ScheduleTimeoutSeconds
 	}
 	minMember := calculateMinAvailable(mpiJob)
+	var minResources corev1.ResourceList
+	if origin := s.calculatePGMinResources(minMember, mpiJob); origin != nil {
+		minResources = *origin
+	}
 	return &schedv1alpha1.PodGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: schedv1alpha1.SchemeGroupVersion.String(),
@@ -246,7 +250,7 @@ func (s *SchedulerPluginsCtrl) newPodGroup(mpiJob *kubeflow.MPIJob) metav1.Objec
 		Spec: schedv1alpha1.PodGroupSpec{
 			MinMember:              *minMember,
 			ScheduleTimeoutSeconds: scheduleTimeoutSec,
-			MinResources:           *s.calculatePGMinResources(minMember, mpiJob),
+			MinResources:           minResources,
 		},
 	}
 }

--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -191,17 +191,22 @@ type SchedulerPluginsCtrl struct {
 	schedulerName       string
 }
 
-func NewSchedulerPluginsCtrl(c schedclientset.Interface, watchNamespace, schedulerName string) *SchedulerPluginsCtrl {
+func NewSchedulerPluginsCtrl(
+	c schedclientset.Interface,
+	watchNamespace, schedulerName string,
+	pcLister schedulinglisters.PriorityClassLister,
+) *SchedulerPluginsCtrl {
 	var informerFactoryOpts []schedinformers.SharedInformerOption
 	if watchNamespace != metav1.NamespaceAll {
 		informerFactoryOpts = append(informerFactoryOpts, schedinformers.WithNamespace(watchNamespace))
 	}
-	informerFactory := schedinformers.NewSharedInformerFactoryWithOptions(c, 0, informerFactoryOpts...)
+	pgInformerFactory := schedinformers.NewSharedInformerFactoryWithOptions(c, 0, informerFactoryOpts...)
 	return &SchedulerPluginsCtrl{
-		Client:           c,
-		InformerFactory:  informerFactory,
-		PodGroupInformer: informerFactory.Scheduling().V1alpha1().PodGroups(),
-		schedulerName:    schedulerName,
+		Client:              c,
+		InformerFactory:     pgInformerFactory,
+		PodGroupInformer:    pgInformerFactory.Scheduling().V1alpha1().PodGroups(),
+		PriorityClassLister: pcLister,
+		schedulerName:       schedulerName,
 	}
 }
 


### PR DESCRIPTION
Currently, we don't pass a lister for priorityClasses to podGroup for the scheduler-plugins. So the nil pointer error happens when the podGroupCtrl for the scheduler-plugins list priorityClasses in the following:

```shell
E0607 07:29:50.611829       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 437 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x19cf5a0?, 0x2d22520})
	/go/pkg/mod/k8s.io/apimachinery@v0.25.7/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00081c620?})
	/go/pkg/mod/k8s.io/apimachinery@v0.25.7/pkg/util/runtime/runtime.go:49 +0x75
panic({0x19cf5a0, 0x2d22520})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/kubeflow/mpi-operator/pkg/controller.(*SchedulerPluginsCtrl).calculatePGMinResources(0xc0008051d0, 0xc0014d971c, 0x1c7368d?)
	/go/src/github.com/kubeflow/mpi-operator/pkg/controller/podgroup.go:314 +0x1cc
github.com/kubeflow/mpi-operator/pkg/controller.(*SchedulerPluginsCtrl).newPodGroup(0xc001d86750?, 0xc000a19d40)
	/go/src/github.com/kubeflow/mpi-operator/pkg/controller/podgroup.go:249 +0x18a
github.com/kubeflow/mpi-operator/pkg/controller.(*MPIJobController).getOrCreatePodGroups(0xc00074cc60, 0xc000a19d40?)
```

So, I passed a lister for the priorityClass to podGroupCtrl for the scheduler-plugins.
