### PR TITLE
update volcano scheduler to 1.8.0; ignore vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ profile.cov
 hack/python-sdk/openapi-generator-cli.jar
 dep-crds/
 dep-manifests/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ volcano-scheduler:
 .PHONY: volcano-scheduler-crd
 volcano-scheduler-crd: volcano-scheduler
 	mkdir -p $(PROJECT_DIR)/dep-crds/volcano-scheduler/
-	cp -f /tmp/pkg/mod/volcano.sh/volcano@$(VOLCANO_SCHEDULER_VERSION)/config/crd/bases/* $(PROJECT_DIR)/dep-crds/volcano-scheduler
+	cp -f /tmp/pkg/mod/volcano.sh/volcano@$(VOLCANO_SCHEDULER_VERSION)/config/crd/volcano/bases/* $(PROJECT_DIR)/dep-crds/volcano-scheduler
 
 .PHONY: volcano-scheduler-deploy
 volcano-scheduler-deploy: volcano-scheduler-crd

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.15.1
 	sigs.k8s.io/scheduler-plugins v0.26.7
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
-	volcano.sh/apis v1.7.0
+	volcano.sh/apis v1.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -696,5 +696,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ih
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-volcano.sh/apis v1.7.0 h1:seGlnTcyT2VBst+ypaTffekWdasV+siwluPXNpT8e54=
-volcano.sh/apis v1.7.0/go.mod h1:xe38GChdXXam/g/FkQXIsR0vhqp4twoZdY2gaGkEP24=
+volcano.sh/apis v1.8.0 h1:TO9mxoqLMToBAEB195OPuiC3pnupqsUqfXVJroT7KEI=
+volcano.sh/apis v1.8.0/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=


### PR DESCRIPTION
Fix issue #586
To keep update for volcano release 1.8.0