### PR TITLE
Fix invalid link for horovod cpu-only example Dockerfile

### DIFF
--- a/examples/v2beta1/horovod/README.md
+++ b/examples/v2beta1/horovod/README.md
@@ -4,7 +4,7 @@ This example shows how to run a cpu-only mpijob.
 
 ## How to Build Image
 
-This example dockerfile is based on Horovod cpu only [dockerfile](https://raw.githubusercontent.com/horovod/horovod/master/Dockerfile.cpu), you can build the image as follows:
+This example dockerfile is based on Horovod cpu only [dockerfile](https://raw.githubusercontent.com/horovod/horovod/master/docker/horovod-cpu/Dockerfile), you can build the image as follows:
 
 ```bash
 docker build -t horovod:latest .


### PR DESCRIPTION
I just realized the link of Dockerfile is also invalid, submit another PR to fix.
