### PR TITLE
fix the condition

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -639,7 +639,7 @@ func (c *MPIJobController) syncHandler(key string) error {
 			}
 		}
 		if launcher == nil {
-			if mpiJob.Spec.LauncherCreationPolicy == kubeflow.LauncherCreationPolicyAtStartup || c.countReadyWorkerPods(worker) == len(worker) {
+			if mpiJob.Spec.LauncherCreationPolicy == kubeflow.LauncherCreationPolicyAtStartup || (!isMPIJobSuspended(mpiJob) && c.countReadyWorkerPods(worker) == len(worker)) {
 				launcher, err = c.kubeClient.BatchV1().Jobs(namespace).Create(context.TODO(), c.newLauncherJob(mpiJob), metav1.CreateOptions{})
 				if err != nil {
 					c.recorder.Eventf(mpiJob, corev1.EventTypeWarning, mpiJobFailedReason, "launcher pod created failed: %v", err)


### PR DESCRIPTION
fixes #615 

The original logic is:
```go
if launcher == nil {
	if mpiJob.Spec.LauncherCreationPolicy == kubeflow.LauncherCreationPolicyAtStartup ||  c.countReadyWorkerPods(worker) == len(worker) {
		launcher, err = c.kubeClient.BatchV1().Jobs(namespace).Create(context.TODO(), c.newLauncherJob(mpiJob), metav1.CreateOptions{})
		....
}
```
If the MPIJob is `suspended`, the `len(worker)` and `c.countReadyWorkerPods(worker)` would be both `0`. Then this judgment condition will be meet, and the launcher pod will be created.