### PR TITLE
adding timeout for cache sync

### DIFF
--- a/cmd/mpi-operator/app/options/options.go
+++ b/cmd/mpi-operator/app/options/options.go
@@ -39,7 +39,7 @@ type ServerOption struct {
 	LockNamespace      string
 	QPS                int
 	Burst              int
-	CacheTimeout       time.Duration
+	CacheSyncTimeout   time.Duration
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -78,6 +78,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&s.QPS, "kube-api-qps", 5, "QPS indicates the maximum QPS to the master from this client.")
 	fs.IntVar(&s.Burst, "kube-api-burst", 10, "Maximum burst for throttle.")
 
-	fs.DurationVar(&s.CacheTimeout, "cache-timeout", 30*time.Second,
+	fs.DurationVar(&s.CacheSyncTimeout, "cache-sync-timeout", 2*time.Minute,
 		`The amount of time to wait for caches to populate. If this timeout is exceeded, the mpi-operator will fail and exit.`)
 }

--- a/cmd/mpi-operator/app/options/options.go
+++ b/cmd/mpi-operator/app/options/options.go
@@ -17,6 +17,7 @@ package options
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 )
@@ -38,6 +39,7 @@ type ServerOption struct {
 	LockNamespace      string
 	QPS                int
 	Burst              int
+	CacheTimeout       time.Duration
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -75,4 +77,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.IntVar(&s.QPS, "kube-api-qps", 5, "QPS indicates the maximum QPS to the master from this client.")
 	fs.IntVar(&s.Burst, "kube-api-burst", 10, "Maximum burst for throttle.")
+
+	fs.DurationVar(&s.CacheTimeout, "cache-timeout", 30*time.Second,
+		`The amount of time to wait for caches to populate. If this timeout is exceeded, the mpi-operator will fail and exit.`)
 }

--- a/cmd/mpi-operator/app/server.go
+++ b/cmd/mpi-operator/app/server.go
@@ -166,7 +166,7 @@ func Run(opt *options.ServerOption) error {
 
 		// Set leader election start function.
 		isLeader.Set(1)
-		if err = controller.Run(opt.Threadiness, stopCh, opt.CacheTimeout); err != nil {
+		if err = controller.Run(opt.Threadiness, stopCh, opt.CacheSyncTimeout); err != nil {
 			klog.Fatalf("Error running controller: %s", err.Error())
 		}
 	}

--- a/cmd/mpi-operator/app/server.go
+++ b/cmd/mpi-operator/app/server.go
@@ -166,7 +166,7 @@ func Run(opt *options.ServerOption) error {
 
 		// Set leader election start function.
 		isLeader.Set(1)
-		if err = controller.Run(opt.Threadiness, stopCh); err != nil {
+		if err = controller.Run(opt.Threadiness, stopCh, opt.CacheTimeout); err != nil {
 			klog.Fatalf("Error running controller: %s", err.Error())
 		}
 	}

--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -421,7 +421,7 @@ func NewMPIJobControllerWithClock(
 // as syncing informer caches and starting workers. It will block until stopCh
 // is closed, at which point it will shutdown the work queue and wait for
 // workers to finish processing their current work items.
-func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}) error {
+func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}, cacheTimeout time.Duration) error {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -442,7 +442,7 @@ func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}) error {
 		synced = append(synced, c.podGroupSynced, c.priorityClassSynced)
 	}
 
-	timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), cacheTimeout)
 	defer cancel()
 
 	if ok := cache.WaitForCacheSync(timeout.Done(), synced...); !ok {

--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -443,6 +443,8 @@ func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	if ok := cache.WaitForCacheSync(timeout.Done(), synced...); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -421,7 +421,7 @@ func NewMPIJobControllerWithClock(
 // as syncing informer caches and starting workers. It will block until stopCh
 // is closed, at which point it will shutdown the work queue and wait for
 // workers to finish processing their current work items.
-func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}, cacheTimeout time.Duration) error {
+func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}, cacheSyncTimeout time.Duration) error {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -442,7 +442,7 @@ func (c *MPIJobController) Run(threadiness int, stopCh <-chan struct{}, cacheTim
 		synced = append(synced, c.podGroupSynced, c.priorityClassSynced)
 	}
 
-	timeout, cancel := context.WithTimeout(context.Background(), cacheTimeout)
+	timeout, cancel := context.WithTimeout(context.Background(), cacheSyncTimeout)
 	defer cancel()
 
 	if ok := cache.WaitForCacheSync(timeout.Done(), synced...); !ok {


### PR DESCRIPTION
Currently, if informer cache syncing fails (typically because lack of permissions), there is no indication of this error. A message is logged indefinitely, the Pod remains in Running state, and "seems" to be healthy.

The PR adds a timeout to cache syncing, which will fail the controller if caches are not synced [within the timeout period].