### PR TITLE
adding Mac .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ hack/python-sdk/openapi-generator-cli.jar
 dep-crds/
 dep-manifests/
 vendor/
+.DS_Store


### PR DESCRIPTION
Adds the immortal and omnipresent (on Macs!) `.DS_Store` file to `.gitignore`.