### PR TITLE
Fix: no overwrite when run launcher as worker

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1534,12 +1534,13 @@ func (c *MPIJobController) newLauncherPodTemplate(mpiJob *kubeflow.MPIJob) corev
 	case kubeflow.MPIImplementationMPICH:
 		container.Env = append(container.Env, mpichEnvVars...)
 	}
-
-	container.Env = append(container.Env,
-		// We overwrite these environment variables so that users will not
-		// be mistakenly using GPU resources for launcher due to potential
-		// issues with scheduler/container technologies.
-		nvidiaDisableEnvVars...)
+	if !ptr.Deref(mpiJob.Spec.RunLauncherAsWorker, false) {
+		container.Env = append(container.Env,
+			// We overwrite these environment variables so that users will not
+			// be mistakenly using GPU resources for launcher due to potential
+			// issues with scheduler/container technologies.
+			nvidiaDisableEnvVars...)
+	}
 	c.setupSSHOnPod(&podTemplate.Spec, mpiJob)
 
 	// Submit a warning event if the user specifies restart policy for


### PR DESCRIPTION
Default implementation overwrite envs `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` which is not work in the `RunLauncherAsWorker` case with GPU.