### PR TITLE
Introduce debian bookworm

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG port=2222
 

--- a/build/base/intel-builder.Dockerfile
+++ b/build/base/intel-builder.Dockerfile
@@ -2,7 +2,7 @@ FROM bash AS downloader
 
 RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB -O key.PUB
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 COPY --from=downloader key.PUB /tmp/key.PUB
 
@@ -16,7 +16,7 @@ RUN apt update \
     && apt autoremove -y \
     && apt update \
     && apt install -y --no-install-recommends \
-        libstdc++-10-dev binutils procps clang \
+        libstdc++-12-dev binutils procps clang \
         intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mpi-devel \
     && rm -rf /var/lib/apt/lists/*

--- a/build/base/mpich-builder.Dockerfile
+++ b/build/base/mpich-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye as builder
+FROM debian:bookworm as builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/build/base/openmpi-builder.Dockerfile
+++ b/build/base/openmpi-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye as builder
+FROM debian:bookworm as builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/examples/v2beta1/pi/pi.cc
+++ b/examples/v2beta1/pi/pi.cc
@@ -46,6 +46,7 @@ int main(int argc, char *argv[]) {
     double pi = 4 * (double)total_count / (double)(worker_tests) / (double)(workers);
     printf("pi is approximately %.16lf\n", pi);
   }
+  MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();
   return 0;
 }


### PR DESCRIPTION
I upgraded the Debian bullseye to the bookworm. The bookworm allows us to use the following MPI versions.

- OpenMPI: [v4.1.0](https://packages.debian.org/bullseye/openmpi-bin) ->  [v4.1.4](https://packages.debian.org/bookworm/openmpi-bin)
- IntelMPI: 2021.13.1 -> 2021.13.1 (without changes)
- MPICH: [3.4.1](https://packages.debian.org/bullseye/mpich) -> [4.0.2](https://packages.debian.org/bookworm/mpich)

### Side Effect

The new bookworm contains the v4 MPICH, but in the MPICH v4, it seems that we need to obviously verify if all Ranks are finalized using `MPI_Barrier()` before `MPI_Finalize()`. If we do not verify it, the rendezvous point will be closed before all Ranks are finalized, and then the Worker Ranks will be stuck forever, even if all Ranks succeeded, as observed at #573.

There is a similar situation: https://github.com/pmodels/mpich/issues/6584

Fixes: #573 