### PR TITLE
Obviously specify the supported platforms in Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,4 +47,11 @@ jobs:
       with:
         go-version-file: go.mod
     - name: Run tests
-      run: make RELEASE_VERSION=test CONTROLLER_VERSION=v2 TEST_KIND_IMAGE=kindest/node:${{ matrix.kubernetes-version }} test_e2e
+      env:
+        RELEASE_VERSION: test
+        CONTROLLER_VERSION: v2
+        TEST_KIND_IMAGE: kindest/node:${{ matrix.kubernetes-version }}
+        PLATFORMS: linux/amd64
+        INTEL_PLATFORMS: linux/amd64
+        MPICH_PLATFORMS: linux/amd64
+      run: make test_e2e

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,15 @@
 
 BIN_DIR=_output/cmd/bin
 REPO_PATH="github.com/kubeflow/mpi-operator"
-REL_OSARCH="linux/amd64"
 GitSHA=$(shell git rev-parse HEAD)
 Date=$(shell date "+%Y-%m-%d %H:%M:%S")
 RELEASE_VERSION?=v0.5.0
 CONTROLLER_VERSION?=v2
 BASE_IMAGE_SSH_PORT?=2222
 IMG_BUILDER=docker
-PLATFORMS ?= linux/amd64
+PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le
 INTEL_PLATFORMS ?= linux/amd64
-MPICH_PLATFORMS ?= linux/amd64
+MPICH_PLATFORMS ?= linux/amd64,linux/arm64
 LD_FLAGS_V2=" \
     -X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
     -X '${REPO_PATH}/pkg/version.Built=${Date}'   \


### PR DESCRIPTION
I specified the supported platforms in Makefile, and removed unused `REL_OSARCH`.
This allows us to easily image.

- mpi-operator: linux/amd64,linux/arm64,linux/ppc64le (https://hub.docker.com/layers/mpioperator/mpi-operator/master/images/sha256-7824358c9418ccc23c3fe31dedabca593c3ea461be05e2723ab12fe98fb13067?context=explore)
- OpenMPI: linux/amd64,linux/arm64,linux/ppc64le (https://hub.docker.com/layers/mpioperator/openmpi-builder/latest/images/sha256-5c1039705e5d8a897f7b88f2726e615a619f2aba21a95955353382503f19d721?context=explore)
- IntelMPI: linux/amd64,linux/arm64 (https://hub.docker.com/layers/mpioperator/mpich-builder/latest/images/sha256-323deb1e2e944910ffac7edab78f67168a5372540312ff8d6dfc2b6791c3d18e?context=explore)
- MPICH: linux/amd64 (https://hub.docker.com/layers/mpioperator/intel-builder/latest/images/sha256-175acb7ade64f5fdb1c692f528f14b60d33e3512d8ce69f232f50ecb125e7404?context=explore)