### PR TITLE
Fix crash in podgroup when runLauncherAsWorker is true

### DIFF
--- a/pkg/controller/podgroup.go
+++ b/pkg/controller/podgroup.go
@@ -356,7 +356,12 @@ func calPGMinResource(minMember *int32, mpiJob *kubeflow.MPIJob, pcLister schedu
 
 	sort.Sort(sort.Reverse(order))
 	// Launcher + Worker > minMember
-	if minMember != nil && *order[0].Replicas+*order[1].Replicas > *minMember {
+	replicas := *order[0].Replicas
+	if len(order) > 1 {
+		// When using runLauncherAsWorker, there may be no worker.
+		replicas += *order[1].Replicas
+	}
+	if minMember != nil && replicas > *minMember {
 		// If the launcher and workers have the same priority, it treats workers as a lower priority.
 		if order[0].priority == order[1].priority {
 			wIndex := order.getWorkerIndex()

--- a/pkg/controller/podgroup_test.go
+++ b/pkg/controller/podgroup_test.go
@@ -520,7 +520,7 @@ func TestCalculatePGMinResources(t *testing.T) {
 			},
 		},
 		"without worker without priorityClass": {
-			minMember: 3,
+			minMember: 1,
 			job: &kubeflow.MPIJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",


### PR DESCRIPTION
When runLauncherAsWorker is true and there is no worker, the MPI controller will crash in `calPGMinResource`