### PR TITLE
Upgrade Debian version to trixie for OpenMPI v5.0

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 ARG port=2222
 

--- a/build/base/intel-builder.Dockerfile
+++ b/build/base/intel-builder.Dockerfile
@@ -2,23 +2,23 @@ FROM bash AS downloader
 
 RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB -O key.PUB
 
-FROM debian:bookworm
+FROM debian:trixie
 
 COPY --from=downloader key.PUB /tmp/key.PUB
 
 # Install Intel oneAPI keys.
 RUN apt update \
-    && apt install -y --no-install-recommends gnupg2 ca-certificates \
-    && apt-key add /tmp/key.PUB \
+    && apt install -y --no-install-recommends gnupg2 ca-certificates apt-transport-https \
+    && gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg /tmp/key.PUB \
     && rm /tmp/key.PUB \
-    && echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
-    && apt remove -y gnupg2 ca-certificates \
-    && apt autoremove -y \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
     && apt update \
     && apt install -y --no-install-recommends \
         libstdc++-12-dev binutils procps clang \
         intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mpi-devel-2021.13 \
+    && apt remove -y gnupg2 ca-certificates apt-transport-https \
+    && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV I_MPI_CC=clang I_MPI_CXX=clang++

--- a/build/base/intel.Dockerfile
+++ b/build/base/intel.Dockerfile
@@ -10,16 +10,16 @@ COPY --from=downloader key.PUB /tmp/key.PUB
 
 # Install Intel oneAPI keys.
 RUN apt update \
-    && apt install -y --no-install-recommends gnupg2 ca-certificates \
-    && apt-key add /tmp/key.PUB \
+    && apt install -y --no-install-recommends gnupg2 ca-certificates apt-transport-https \
+    && gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg /tmp/key.PUB \
     && rm /tmp/key.PUB \
-    && echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
-    && apt remove -y gnupg2 ca-certificates \
-    && apt autoremove -y \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
     && apt update \
     && apt install -y --no-install-recommends \
         dnsutils \
         intel-oneapi-mpi-2021.13 \
+    && apt remove -y gnupg2 ca-certificates \
+    && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/build/base/mpich-builder.Dockerfile
+++ b/build/base/mpich-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm as builder
+FROM debian:trixie as builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/build/base/openmpi-builder.Dockerfile
+++ b/build/base/openmpi-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm as builder
+FROM debian:trixie as builder
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
I upgraded the Debian version to Trixie to provide OpenMPI v5.0 since some new ML tools like [MLX](https://github.com/ml-explore/mlx) require OpenMPI v5.0.
This is a good opportunity to leverage mpi-operator as an ML ecosystem.

/assign @alculquicondor @terrytangyuan 
