### PR TITLE
Fix missing ReplicaIndexLabel when using RunLauncherAsWorker

### DIFF
--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -1391,6 +1391,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 								kubeflow.OperatorNameLabel: kubeflow.OperatorName,
 								kubeflow.JobNameLabel:      "foo",
 								kubeflow.JobRoleLabel:      "launcher",
+								kubeflow.ReplicaIndexLabel: "0",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -1445,7 +1446,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 						kubeflow.OperatorNameLabel: kubeflow.OperatorName,
 						kubeflow.JobNameLabel:      "foo",
 						kubeflow.JobRoleLabel:      "worker",
-						kubeflow.ReplicaIndexLabel: "0",
+						kubeflow.ReplicaIndexLabel: "1",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Kueue's TAS expects all pods in a Pod Group to have the pod index label. Else it starts printing out annoying errors like `failed to read rank information from Pods`. The latter happens when using RunLauncherAsWorker. To fix this we need to add the pod index label to the launchers' pod.