### PR TITLE
Trust the Intel OneAPI PGP key until it satisfies new APT PGP requirments

### DIFF
--- a/build/base/intel-builder.Dockerfile
+++ b/build/base/intel-builder.Dockerfile
@@ -11,7 +11,9 @@ RUN apt update \
     && apt install -y --no-install-recommends gnupg2 ca-certificates apt-transport-https \
     && gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg /tmp/key.PUB \
     && rm /tmp/key.PUB \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
+    # TODO (tenzen-y): Once Intel OneAPI supports new parsable PGP format for apt, we should remove `trusted=yes` option.
+    # REF: https://github.com/kubeflow/mpi-operator/issues/691
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg trusted=yes] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
     && apt update \
     && apt install -y --no-install-recommends \
         libstdc++-12-dev binutils procps clang \

--- a/build/base/intel.Dockerfile
+++ b/build/base/intel.Dockerfile
@@ -13,7 +13,9 @@ RUN apt update \
     && apt install -y --no-install-recommends gnupg2 ca-certificates apt-transport-https \
     && gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg /tmp/key.PUB \
     && rm /tmp/key.PUB \
-    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
+    # TODO (tenzen-y): Once Intel OneAPI supports new parsable PGP format for apt, we should remove `trusted=yes` option.
+    # REF: https://github.com/kubeflow/mpi-operator/issues/691
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg trusted=yes] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list \
     && apt update \
     && apt install -y --no-install-recommends \
         dnsutils \


### PR DESCRIPTION
By these specification changes, all mpi-operator Intel image building failed.

Workaround for https://github.com/kubeflow/mpi-operator/issues/691