### PR TITLE
Use cncf-hosted gha runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,7 @@ jobs:
         run: make test
   e2e:
     name: E2E
-    runs-on:
-      labels: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:

--- a/.github/workflows/mpi-operator-docker-image-publish.yml
+++ b/.github/workflows/mpi-operator-docker-image-publish.yml
@@ -15,8 +15,7 @@ env:
 
 jobs:
   build-push-docker-image:
-    runs-on:
-      labels: ubuntu-latest-16-cores
+    runs-on: oracle-16cpu-64gb-x86-64
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners in Oracle that we're wanting projects to use rather than the GitHub hosted ones, which are now incur a cost to use. This PR is currently a WIP to work through any tests that break or dependencies that may be missing. <3

Please direct any questions to myself, @krook and @RobertKielty