### PR TITLE
Support cluster domain for MPI HostFile

### DIFF
--- a/cmd/mpi-operator/app/options/options.go
+++ b/cmd/mpi-operator/app/options/options.go
@@ -40,6 +40,7 @@ type ServerOption struct {
 	Burst               int
 	ControllerRateLimit int
 	ControllerBurst     int
+	ClusterDomain       string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -80,4 +81,8 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.IntVar(&s.ControllerRateLimit, "controller-queue-rate-limit", 10, "Rate limit of the controller events queue .")
 	fs.IntVar(&s.ControllerBurst, "controller-queue-burst", 100, "Maximum burst of the controller events queue.")
+
+	fs.StringVar(&s.ClusterDomain, "cluster-domain", "", `
+			The cluster domain is used to construct MPI HostFile. When this is specified, the HostFile is built with "<pod-name>.<mpi-job-name>.<namespace>.svc.<cluster-domain>". 
+			Otherwise, that is built with <pod-name>.<mpi-job-name>.<namespace>.svc`)
 }


### PR DESCRIPTION
I added `--cluster-domain` option to add the cluster domain when MPIOperator constructs MPI HostFile.
When it is specified the HostFile domains are built with `<pod-name>.<mpi-job-name>.<namespace>.svc.<cluster-domain>` format. Otherwise, `<pod-name>.<mpi-job-name>.<namespace>.svc` is used the same as previously.

#### Background

In https://github.com/kubeflow/mpi-operator/issues/453, we added `<namespace>.svc` suffix to address a special network environment. But, it is not an ideal endpoint name format for the generic network environment, where `svc.<cluster-domain>` is configured by the kubelet. As a result, there are many DNS name resolutions trying until hitting the domain w/out a cluster domain. That causes the Launcher Job to be recreated many times due to the failure of DNS name resolution.

This is quite impacted in the runLauncherAsWorker environment since Launcher is launched very fast before the svc.<cluster-domain> is set up.