### PR TITLE
Use 'on' in favor of 'if' for gh action workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,16 @@
 name: golangci-lint
 on:
   push:
-    tags:
-      - v*
     branches:
-      - master
+    - "master"
+    - "release-*"
+    tags:
+    - "v*"
   pull_request:
+    branches:
+    - "master"
+    - "release-*"
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,16 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - "master"
+    - "release-*"
+    tags:
+    - "v*"
+  pull_request:
+    branches:
+    - "master"
+    - "release-*"
+
 jobs:
   validate:
     name: Validate
@@ -9,8 +20,6 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/mpi-operator
-    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone the code
         uses: actions/checkout@v3
@@ -34,8 +43,6 @@ jobs:
     name: E2E
     runs-on:
       labels: ubuntu-latest-16-cores
-    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mpi-operator-docker-image-publish.yml
+++ b/.github/workflows/mpi-operator-docker-image-publish.yml
@@ -3,12 +3,14 @@ name: build and publish mpi multi-arch docker image
 on:
   push:
     branches:
-      - "master"
+    - "master"
+    - "release-*"
     tags:
-      - "v*"
+    - "v*"
   pull_request:
     branches:
-      - "master"
+    - "master"
+    - "release-*"
 
 env:
   IMAGE_NAME: mpioperator/mpi-operator


### PR DESCRIPTION
I replaced `if` statement with `on` since the skipped gh action workflow status block auto merge by prow due to `tide Not mergeable. Job E2E has not succeeded.` reason.

e.g., https://github.com/kubeflow/mpi-operator/pull/701