### PR TITLE
Upgrade Go version to v1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.25 AS build
 
 # Set mpi-operator version
 # Defaults to v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/mpi-operator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.4.0


### PR DESCRIPTION
I upgraded Go version to v1.25.

This is blocking the following PRs:

- https://github.com/kubeflow/mpi-operator/pull/734
- https://github.com/kubeflow/mpi-operator/pull/735
- https://github.com/kubeflow/mpi-operator/pull/736
- https://github.com/kubeflow/mpi-operator/pull/737
- https://github.com/kubeflow/mpi-operator/pull/738