### PR TITLE
Replace deprecated commonLabels with labels in dev overlay

### DIFF
--- a/manifests/overlays/dev/kustomization.yaml.template
+++ b/manifests/overlays/dev/kustomization.yaml.template
@@ -4,11 +4,12 @@ resources:
 - ../../base
 - namespace.yaml
 namespace: mpi-operator
-commonLabels:
-  kustomize.component: mpi-operator
-  app: mpi-operator
-  app.kubernetes.io/name: mpi-operator
-  app.kubernetes.io/component: mpijob
+labels:
+- pairs:
+    kustomize.component: mpi-operator
+    app: mpi-operator
+    app.kubernetes.io/name: mpi-operator
+    app.kubernetes.io/component: mpijob
 images:
 - name: mpioperator/mpi-operator
   newName: %IMAGE_NAME%


### PR DESCRIPTION
This PR is a follow-up of https://github.com/kubeflow/mpi-operator/pull/700.
