### PR TITLE
Update image tag with release-0.7

### DIFF
--- a/deploy/v2beta1/mpi-operator.yaml
+++ b/deploy/v2beta1/mpi-operator.yaml
@@ -9143,6 +9143,6 @@ spec:
       - args:
         - -alsologtostderr
         - --lock-namespace=mpi-operator
-        image: mpioperator/mpi-operator:master
+        image: mpioperator/mpi-operator:0.7
         name: mpi-operator
       serviceAccountName: mpi-operator

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -17,3 +17,7 @@ labels:
     app.kubernetes.io/component: mpijob
     app.kubernetes.io/name: mpi-operator
     kustomize.component: mpi-operator
+images:
+- name: mpioperator/mpi-operator
+  newName: mpioperator/mpi-operator
+  newTag: "0.7"

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: mpi-operator
 images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
-  newTag: master
+  newTag: "0.7"
 patches:
 - path: ./patch.yaml
   target:


### PR DESCRIPTION
Part of https://github.com/kubeflow/mpi-operator/issues/740

NOTE: the previous (v0.6) one is https://github.com/kubeflow/mpi-operator/pull/668 just for reference
