### PR TITLE
Fix Running condition being re-emitted when pod and job informers are out-of-sync

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1160,6 +1160,30 @@ func (c *MPIJobController) updateMPIJobStatus(mpiJob *kubeflow.MPIJob, launcher 
 	if isMPIJobSuspended(mpiJob) {
 		msg := fmt.Sprintf("MPIJob %s/%s is suspended.", mpiJob.Namespace, mpiJob.Name)
 		updateMPIJobConditions(mpiJob, kubeflow.JobRunning, corev1.ConditionFalse, mpiJobSuspendedReason, msg)
+	} else if isFinished(mpiJob.Status) {
+		// Job reached a terminal state. Do not re-emit Running=True to avoid having a LastTransition time after
+		// the completion time.
+		// If Running was never set (e.g. job completed before the operator observed it running), add Running=False
+		// using the completionTime so that consumers computing duration still find the condition and can make
+		// some guesses about the job lifecycle.
+		if getCondition(mpiJob.Status, kubeflow.JobRunning) == nil {
+			msg := fmt.Sprintf("MPIJob %s/%s is finished but Running condition was never set.", mpiJob.Namespace, mpiJob.Name)
+			cond := kubeflow.JobCondition{
+				Type:    kubeflow.JobRunning,
+				Status:  corev1.ConditionFalse,
+				Reason:  mpiJobRunningReason,
+				Message: msg,
+			}
+			if mpiJob.Status.CompletionTime != nil {
+				cond.LastTransitionTime = *mpiJob.Status.CompletionTime
+				cond.LastUpdateTime = *mpiJob.Status.CompletionTime
+			} else {
+				now := metav1.Now()
+				cond.LastTransitionTime = now
+				cond.LastUpdateTime = now
+			}
+			mpiJob.Status.Conditions = append(mpiJob.Status.Conditions, cond)
+		}
 	} else if launcher != nil && launcherPodsCnt >= 1 && running == len(worker) {
 		msg := fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
 		updateMPIJobConditions(mpiJob, kubeflow.JobRunning, corev1.ConditionTrue, mpiJobRunningReason, msg)

--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1174,14 +1174,10 @@ func (c *MPIJobController) updateMPIJobStatus(mpiJob *kubeflow.MPIJob, launcher 
 				Reason:  mpiJobRunningReason,
 				Message: msg,
 			}
-			if mpiJob.Status.CompletionTime != nil {
-				cond.LastTransitionTime = *mpiJob.Status.CompletionTime
-				cond.LastUpdateTime = *mpiJob.Status.CompletionTime
-			} else {
-				now := metav1.Now()
-				cond.LastTransitionTime = now
-				cond.LastUpdateTime = now
-			}
+			updateTime := ptr.Deref(mpiJob.Status.CompletionTime, metav1.NewTime(c.clock.Now()))
+			cond.LastTransitionTime = updateTime
+			cond.LastUpdateTime = updateTime
+
 			mpiJob.Status.Conditions = append(mpiJob.Status.Conditions, cond)
 		}
 	} else if launcher != nil && launcherPodsCnt >= 1 && running == len(worker) {

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -629,6 +629,71 @@ func TestLauncherSucceeded(t *testing.T) {
 	updateMPIJobConditions(mpiJobCopy, kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, msg)
 	msg = fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
 	updateMPIJobConditions(mpiJobCopy, kubeflow.JobSucceeded, corev1.ConditionTrue, mpiJobSucceededReason, msg)
+	// Running=False is added when the job finishes without Running ever being set.
+	msg = fmt.Sprintf("MPIJob %s/%s is finished but Running condition was never set.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, kubeflow.JobRunning, corev1.ConditionFalse, mpiJobRunningReason, msg)
+	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
+
+	f.run(t.Context(), getKey(mpiJob, t))
+}
+
+// TestLauncherSucceededWithRunningPod tests that when a launcher Job has succeeded but its pod is still observed as Running due to
+// informer lag). Workers have been cleaned up. The Running condition is set to False rather than being re-emitted as True alongside
+// Succeeded.
+func TestLauncherSucceededWithRunningPod(t *testing.T) {
+	f := newFixture(t, "")
+
+	startTime := metav1.Now()
+	completionTime := metav1.Now()
+
+	mpiJob := newMPIJob("test", ptr.To[int32](64), &startTime, &completionTime)
+	// Pre-set the Running condition to simulate a job that was running before completion.
+	msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJob, kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJob, kubeflow.JobRunning, corev1.ConditionTrue, mpiJobRunningReason, msg)
+	f.setUpMPIJob(mpiJob)
+
+	fmjc := f.newFakeMPIJobController()
+	mpiJobCopy := mpiJob.DeepCopy()
+	scheme.Scheme.Default(mpiJobCopy)
+	launcher := fmjc.newLauncherJob(mpiJobCopy)
+	// Launcher Job has succeeded.
+	launcher.Status.Conditions = append(launcher.Status.Conditions, []batchv1.JobCondition{
+		{
+			Type:   batchv1.JobSuccessCriteriaMet,
+			Status: corev1.ConditionTrue,
+		},
+		{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		},
+	}...)
+	launcher.Status.StartTime = &startTime
+	launcher.Status.CompletionTime = &completionTime
+	f.setUpLauncher(launcher)
+
+	// Launcher pod is still observed as Running despite the Job having completed.
+	launcherPod := mockJobPod(launcher)
+	launcherPod.Status.Phase = corev1.PodRunning
+	f.setUpPod(launcherPod)
+
+	mpiJobCopy.Status.ReplicaStatuses = map[kubeflow.MPIReplicaType]*kubeflow.ReplicaStatus{
+		kubeflow.MPIReplicaTypeLauncher: {
+			Active:    0,
+			Succeeded: 1,
+			Failed:    0,
+		},
+		kubeflow.MPIReplicaTypeWorker: {},
+	}
+	setUpMPIJobTimestamp(mpiJobCopy, &startTime, &completionTime)
+
+	msg = fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, kubeflow.JobRunning, corev1.ConditionFalse, mpiJobRunningReason, msg)
+	msg = fmt.Sprintf("MPIJob %s/%s successfully completed.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, kubeflow.JobSucceeded, corev1.ConditionTrue, mpiJobSucceededReason, msg)
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
 	f.run(t.Context(), getKey(mpiJob, t))
@@ -692,6 +757,9 @@ func TestLauncherFailed(t *testing.T) {
 	updateMPIJobConditions(mpiJobCopy, kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, msg)
 	msg = "Job has reached the specified backoff limit: second message"
 	updateMPIJobConditions(mpiJobCopy, kubeflow.JobFailed, corev1.ConditionTrue, batchv1.JobReasonBackoffLimitExceeded+"/FailedReason2", msg)
+	// Running=False is added when the job finishes without Running ever being set.
+	msg = fmt.Sprintf("MPIJob %s/%s is finished but Running condition was never set.", mpiJob.Namespace, mpiJob.Name)
+	updateMPIJobConditions(mpiJobCopy, kubeflow.JobRunning, corev1.ConditionFalse, mpiJobRunningReason, msg)
 
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -352,7 +352,7 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 		}
 
 		if mpiJob, ok := object.(*kubeflow.MPIJob); ok {
-			assertRunningConditionNotBeforeCompletionTime(t, mpiJob)
+			assertRunningConditionNotAfterCompletionTime(t, mpiJob)
 		}
 	case core.CreateAction:
 		e, _ := expected.(core.CreateAction)
@@ -373,10 +373,10 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 	}
 }
 
-func assertRunningConditionNotBeforeCompletionTime(t *testing.T, mpiJob *kubeflow.MPIJob) {
+func assertRunningConditionNotAfterCompletionTime(t *testing.T, mpiJob *kubeflow.MPIJob) {
 	t.Helper()
 
-	if mpiJob == nil || mpiJob.Status.CompletionTime == nil {
+	if mpiJob == nil || mpiJob.Status.CompletionTime == nil || !isFinished(mpiJob.Status) {
 		return
 	}
 
@@ -386,11 +386,11 @@ func assertRunningConditionNotBeforeCompletionTime(t *testing.T, mpiJob *kubeflo
 	}
 
 	completionTime := mpiJob.Status.CompletionTime.Time
-	if running.LastTransitionTime.Time.Before(completionTime) {
-		t.Errorf("MPIJob %s/%s Running LastTransitionTime %s is before CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastTransitionTime.Time, completionTime)
+	if completionTime.Before(running.LastTransitionTime.Time) {
+		t.Errorf("MPIJob %s/%s Running LastTransitionTime %s is after CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastTransitionTime.Time, completionTime)
 	}
-	if running.LastUpdateTime.Time.Before(completionTime) {
-		t.Errorf("MPIJob %s/%s Running LastUpdateTime %s is before CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastUpdateTime.Time, completionTime)
+	if completionTime.Before(running.LastUpdateTime.Time) {
+		t.Errorf("MPIJob %s/%s Running LastUpdateTime %s is after CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastUpdateTime.Time, completionTime)
 	}
 }
 
@@ -666,10 +666,11 @@ func TestLauncherSucceeded(t *testing.T) {
 // informer lag). Workers have been cleaned up. The Running condition is set to False rather than being re-emitted as True alongside
 // Succeeded.
 func TestLauncherSucceededWithRunningPod(t *testing.T) {
-	fakeClock := clocktesting.NewFakeClock(time.Now().Truncate(time.Second))
+	fakeClock := clocktesting.NewFakeClock(time.Now().Add(-time.Hour).Truncate(time.Second))
 	f := newFixture(t, "")
 
 	startTime := metav1.NewTime(fakeClock.Now())
+	fakeClock.Step(time.Minute)
 	completionTime := metav1.NewTime(fakeClock.Now())
 
 	mpiJob := newMPIJob("test", ptr.To[int32](64), &startTime, &completionTime)
@@ -678,6 +679,12 @@ func TestLauncherSucceededWithRunningPod(t *testing.T) {
 	updateMPIJobConditions(mpiJob, kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, msg)
 	msg = fmt.Sprintf("MPIJob %s/%s is running.", mpiJob.Namespace, mpiJob.Name)
 	updateMPIJobConditions(mpiJob, kubeflow.JobRunning, corev1.ConditionTrue, mpiJobRunningReason, msg)
+	for i := range mpiJob.Status.Conditions {
+		if mpiJob.Status.Conditions[i].Type == kubeflow.JobRunning {
+			mpiJob.Status.Conditions[i].LastTransitionTime = startTime
+			mpiJob.Status.Conditions[i].LastUpdateTime = startTime
+		}
+	}
 	f.setUpMPIJob(mpiJob)
 
 	fmjc := f.newFakeMPIJobController()

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -350,6 +350,10 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 		if diff := cmp.Diff(expObject, object, ignoreSecretEntries, ignoreConditionTimes); diff != "" {
 			t.Errorf("Action %s %s has wrong object (-want +got):\n %s", a.GetVerb(), a.GetResource().Resource, diff)
 		}
+
+		if mpiJob, ok := object.(*kubeflow.MPIJob); ok {
+			assertRunningConditionNotBeforeCompletionTime(t, mpiJob)
+		}
 	case core.CreateAction:
 		e, _ := expected.(core.CreateAction)
 		expObject := e.GetObject()
@@ -366,6 +370,27 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 		if diff := cmp.Diff(expPatch, patch); diff != "" {
 			t.Errorf("Action %s %s has wrong patch (-want +got):\n %s", a.GetVerb(), a.GetResource().Resource, diff)
 		}
+	}
+}
+
+func assertRunningConditionNotBeforeCompletionTime(t *testing.T, mpiJob *kubeflow.MPIJob) {
+	t.Helper()
+
+	if mpiJob == nil || mpiJob.Status.CompletionTime == nil {
+		return
+	}
+
+	running := getCondition(mpiJob.Status, kubeflow.JobRunning)
+	if running == nil {
+		return
+	}
+
+	completionTime := mpiJob.Status.CompletionTime.Time
+	if running.LastTransitionTime.Time.Before(completionTime) {
+		t.Errorf("MPIJob %s/%s Running LastTransitionTime %s is before CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastTransitionTime.Time, completionTime)
+	}
+	if running.LastUpdateTime.Time.Before(completionTime) {
+		t.Errorf("MPIJob %s/%s Running LastUpdateTime %s is before CompletionTime %s", mpiJob.Namespace, mpiJob.Name, running.LastUpdateTime.Time, completionTime)
 	}
 }
 
@@ -641,10 +666,11 @@ func TestLauncherSucceeded(t *testing.T) {
 // informer lag). Workers have been cleaned up. The Running condition is set to False rather than being re-emitted as True alongside
 // Succeeded.
 func TestLauncherSucceededWithRunningPod(t *testing.T) {
+	fakeClock := clocktesting.NewFakeClock(time.Now().Truncate(time.Second))
 	f := newFixture(t, "")
 
-	startTime := metav1.Now()
-	completionTime := metav1.Now()
+	startTime := metav1.NewTime(fakeClock.Now())
+	completionTime := metav1.NewTime(fakeClock.Now())
 
 	mpiJob := newMPIJob("test", ptr.To[int32](64), &startTime, &completionTime)
 	// Pre-set the Running condition to simulate a job that was running before completion.


### PR DESCRIPTION
When the pod and job informers are out-of-sync, it's possible for the launcher job to be finished but the pod be running. In that case, the MPIJob may be considered as completed (when using runLauncherAsWorker and workers having finished). In this scenario, the running condition may be re-emitted with a last transition time after the MPIJob was deemed completed. This results in other controllers watching MPIJob to not be able to evaluate the start and end times using the last transition time of the running condition.

To fix this, we can avoid re-emitting the Running condition. Moreover, we can also ensure that the Running condition is always emitted and that the last transition time is <= the completion time.

Another solution to this would be to re-queue if we see the job and pod informers are out-of-sync but I'm not sure if the latter would be harder to implement.