### PR TITLE
chore: bump Go version to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 # Set mpi-operator version
 # Defaults to v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/mpi-operator
 
-go 1.26.2
+go 1.26.0
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/mpi-operator
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.9.0


### PR DESCRIPTION
## Summary
- Update Go from 1.25.0 to 1.26.2 in `go.mod` and `Dockerfile`

## Motivation
The `Validate` CI job fails because `sigs.k8s.io/controller-runtime/tools/setup-envtest` now requires Go >= 1.26.0:

```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest requires go >= 1.26.0 (running go 1.25.0; GOTOOLCHAIN=local)
```

This is a repo-wide issue affecting all PRs (e.g., #794, #795).

## Changes
- `go.mod`: bump `go 1.25.0` to `go 1.26.2`
- `Dockerfile`: bump `golang:1.25` to `golang:1.26`

## References
- Requested in https://github.com/kubeflow/mpi-operator/pull/794#issuecomment-4184669424 by @tenzen-y

/cc @tenzen-y