### PR TITLE
Prevent terminating launcher pods from being recreated

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1542,6 +1542,14 @@ func (c *MPIJobController) newLauncherJob(mpiJob *kubeflow.MPIJob) *batchv1.Job 
 			ActiveDeadlineSeconds:   mpiJob.Spec.RunPolicy.ActiveDeadlineSeconds,
 			BackoffLimit:            mpiJob.Spec.RunPolicy.BackoffLimit,
 			Template:                c.newLauncherPodTemplate(mpiJob),
+			// Make sure we don't run into https://github.com/kubernetes/kubernetes/issues/115844 where
+			// terminating pods are recreated under certain conditions.
+			// This was initially fixed in https://github.com/kubernetes/kubernetes/pull/117015 which landed
+			// in 1.28. PodReplacementPolicy became GA in k8s 1.34 and the check for PodFailurePolicy was
+			// removed in the middle. Whether the workarounds work depend on the k8s version and the
+			// feature flags being active but it's the best we can do.
+			PodReplacementPolicy: ptr.To(batchv1.Failed),
+			PodFailurePolicy:     &batchv1.PodFailurePolicy{},
 		},
 	}
 	if isMPIJobSuspended(mpiJob) {

--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1544,12 +1544,7 @@ func (c *MPIJobController) newLauncherJob(mpiJob *kubeflow.MPIJob) *batchv1.Job 
 			Template:                c.newLauncherPodTemplate(mpiJob),
 			// Make sure we don't run into https://github.com/kubernetes/kubernetes/issues/115844 where
 			// terminating pods are recreated under certain conditions.
-			// This was initially fixed in https://github.com/kubernetes/kubernetes/pull/117015 which landed
-			// in 1.28. PodReplacementPolicy became GA in k8s 1.34 and the check for PodFailurePolicy was
-			// removed in the middle. Whether the workarounds work depend on the k8s version and the
-			// feature flags being active but it's the best we can do.
 			PodReplacementPolicy: ptr.To(batchv1.Failed),
-			PodFailurePolicy:     &batchv1.PodFailurePolicy{},
 		},
 	}
 	if isMPIJobSuspended(mpiJob) {

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -1462,6 +1462,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 					},
 				},
 				Spec: batchv1.JobSpec{
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1591,6 +1592,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 					},
 				},
 				Spec: batchv1.JobSpec{
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1761,6 +1763,7 @@ func TestNewLauncherAndWorker(t *testing.T) {
 					TTLSecondsAfterFinished: ptr.To[int32](1),
 					ActiveDeadlineSeconds:   ptr.To[int64](2),
 					BackoffLimit:            ptr.To[int32](3),
+					PodReplacementPolicy:    ptr.To(batchv1.Failed),
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{


### PR DESCRIPTION
Avoid running into https://github.com/kubernetes/kubernetes/issues/115844 where pods can be recreated while the launcher pod is terminating resulting in MPIJob duplicating work when using runLauncherAsWorker