### PR TITLE
Fix missing DeepCopy when mutating the launcher job

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -689,31 +689,37 @@ func (c *MPIJobController) syncHandler(key string) error {
 
 	if launcher != nil {
 		if !isMPIJobSuspended(mpiJob) && isJobSuspended(launcher) {
+			launcherCopy := launcher.DeepCopy()
 			// We are unsuspending, hence we need to sync the pod template with the current MPIJob spec.
 			// This is important for interop with Kueue as it may have injected schedulingGates.
 			// Kubernetes validates that a Job template is immutable once StartTime is set,
 			// so we must clear it first via a status sub-resource update (consistent with JobSet).
-			if launcher.Status.StartTime != nil {
-				launcher.Status.StartTime = nil
+			if launcherCopy.Status.StartTime != nil {
+				launcherCopy.Status.StartTime = nil
 				var err error
-				if launcher, err = c.kubeClient.BatchV1().Jobs(namespace).UpdateStatus(context.TODO(), launcher, metav1.UpdateOptions{}); err != nil {
+				if launcherCopy, err = c.kubeClient.BatchV1().Jobs(namespace).UpdateStatus(context.TODO(), launcherCopy, metav1.UpdateOptions{}); err != nil {
 					return err
 				}
 			}
 
 			// Sync mutable scheduling directives (KEP-2926) and unsuspend.
 			desiredPodTemplate := c.newLauncherPodTemplate(mpiJob)
-			syncLauncherSchedulingDirectives(launcher, &desiredPodTemplate)
-			launcher.Spec.Suspend = ptr.To(false)
-			if _, err := c.kubeClient.BatchV1().Jobs(namespace).Update(context.TODO(), launcher, metav1.UpdateOptions{}); err != nil {
+			syncLauncherSchedulingDirectives(launcherCopy, &desiredPodTemplate)
+			launcherCopy.Spec.Suspend = ptr.To(false)
+			updated, err := c.kubeClient.BatchV1().Jobs(namespace).Update(context.TODO(), launcherCopy, metav1.UpdateOptions{})
+			if err != nil {
 				return err
 			}
+			launcher = updated
 		} else if isMPIJobSuspended(mpiJob) && !isJobSuspended(launcher) {
+			launcherCopy := launcher.DeepCopy()
 			// align the suspension state of launcher with the MPIJob.
-			launcher.Spec.Suspend = ptr.To(true)
-			if _, err := c.kubeClient.BatchV1().Jobs(namespace).Update(context.TODO(), launcher, metav1.UpdateOptions{}); err != nil {
+			launcherCopy.Spec.Suspend = ptr.To(true)
+			updated, err := c.kubeClient.BatchV1().Jobs(namespace).Update(context.TODO(), launcherCopy, metav1.UpdateOptions{})
+			if err != nil {
 				return err
 			}
+			launcher = updated
 		}
 	}
 

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/fake"
 	"github.com/kubeflow/mpi-operator/pkg/client/clientset/versioned/scheme"
 	informers "github.com/kubeflow/mpi-operator/pkg/client/informers/externalversions"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -60,6 +61,12 @@ var (
 	ignoreReferences     = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "OwnerReferences")
 )
 
+type reactor struct {
+	verb     string
+	resource string
+	fn       core.ReactionFunc
+}
+
 type fixture struct {
 	t *testing.T
 
@@ -67,6 +74,8 @@ type fixture struct {
 	kubeClient    *k8sfake.Clientset
 	volcanoClient *volcanofake.Clientset
 	schedClient   *schedclientset.Clientset
+
+	kubeReactors []reactor
 
 	// Objects to put in the store.
 	configMapLister       []*corev1.ConfigMap
@@ -96,6 +105,7 @@ func newFixture(t *testing.T, gangSchedulingName string) *fixture {
 	f.objects = []runtime.Object{}
 	f.kubeObjects = []runtime.Object{}
 	f.gangSchedulingName = gangSchedulingName
+	f.kubeReactors = []reactor{}
 	return f
 }
 
@@ -163,6 +173,9 @@ func newMPIJob(name string, replicas *int32, startTime, completionTime *metav1.T
 func (f *fixture) newController(ctx context.Context, clock clock.WithTicker) (*MPIJobController, informers.SharedInformerFactory, kubeinformers.SharedInformerFactory) {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	f.kubeClient = k8sfake.NewSimpleClientset(f.kubeObjects...)
+	for _, r := range f.kubeReactors {
+		f.kubeClient.PrependReactor(r.verb, r.resource, r.fn)
+	}
 	i := informers.NewSharedInformerFactory(f.client, noResyncPeriodFunc())
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeClient, noResyncPeriodFunc())
 
@@ -1044,6 +1057,50 @@ func TestResumeMPIJob(t *testing.T) {
 	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
 
 	f.runWithClock(t.Context(), getKey(mpiJob, t), fakeClock)
+}
+
+func TestUnsuspendLauncherUpdateFailureDoesNotPoisonCache(t *testing.T) {
+	f := newFixture(t, "")
+	f.kubeReactors = append(f.kubeReactors, reactor{"update", "jobs",
+		func(core.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewServiceUnavailable("throttled")
+		}})
+
+	var replicas int32 = 1
+	startTime := metav1.Now()
+	mpiJob := newMPIJob("test", &replicas, &startTime, nil)
+	mpiJob.Spec.RunPolicy.Suspend = ptr.To(false)
+	f.setUpMPIJob(mpiJob)
+
+	scheme.Scheme.Default(mpiJob)
+	f.expectCreateServiceAction(newJobService(mpiJob))
+	cfgMap := newConfigMap(mpiJob, replicas, "")
+	updateDiscoverHostsInConfigMap(cfgMap, mpiJob, nil, "")
+	f.setUpConfigMap(cfgMap)
+	secret, err := newSSHAuthSecret(mpiJob)
+	if err != nil {
+		t.Fatalf("Failed creating secret: %v", err)
+	}
+	f.setUpSecret(secret)
+
+	fmjc := f.newFakeMPIJobController()
+	launcher := fmjc.newLauncherJob(mpiJob)
+	launcher.Spec.Suspend = ptr.To(true)
+	f.setUpLauncher(launcher)
+
+	f.kubeActions = append(f.kubeActions, core.NewCreateAction(schema.GroupVersionResource{Resource: "pods"}, mpiJob.Namespace, fmjc.newWorker(mpiJob, 0)))
+
+	launcherCopy := launcher.DeepCopy()
+	desiredPodTemplate := fmjc.newLauncherPodTemplate(mpiJob)
+	syncLauncherSchedulingDirectives(launcherCopy, &desiredPodTemplate)
+	launcherCopy.Spec.Suspend = ptr.To(false)
+	f.expectUpdateJobAction(launcherCopy)
+
+	f.runExpectError(t.Context(), getKey(mpiJob, t))
+
+	if !ptr.Deref(launcher.Spec.Suspend, false) {
+		t.Errorf("cached launcher Spec.Suspend mutated to false despite failed Update")
+	}
 }
 
 func TestResumeMPIJobWithExistingLauncher(t *testing.T) {


### PR DESCRIPTION
We were mutating the informer's cache when updating the launcher Job. If the update failed, the cache would be poisoned, leaving later reconciles to operate on a launcher description that doesn't match the real state on the API server.