### PR TITLE
fix: correct broken README example paths and kustomize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,15 @@ cd mpi-operator
 kustomize build manifests/overlays/kubeflow | kubectl apply -f -
 ```
 
-Note that since Kubernetes v1.14, `kustomize` became a subcommand in `kubectl` so you can also run the following command instead:
-
-Since Kubernetes v1.21, you can use:
+Note that since Kubernetes v1.14, `kustomize` became a subcommand in `kubectl`.
+Since Kubernetes v1.21, you can also use:
 
 ```bash
 kubectl apply -k manifests/overlays/kubeflow
 ```
 
 ```bash
-kubectl kustomize base | kubectl apply -f -
+kubectl kustomize manifests/overlays/kubeflow | kubectl apply -f -
 ```
 
 ## Creating an MPI Job
@@ -215,13 +214,13 @@ total images/sec: 308.27
 For a sample that uses Intel MPI, see:
 
 ```bash
-cat examples/pi/pi-intel.yaml
+cat examples/v2beta1/pi/pi-intel.yaml
 ```
 
 For a sample that uses MPICH, see:
 
 ```bash
-cat examples/pi/pi-mpich.yaml
+cat examples/v2beta1/pi/pi-mpich.yaml
 ```
 
 ## Exposed Metrics


### PR DESCRIPTION
This fixes a couple README commands that break on a fresh clone. Small papercut, but pretty user-facing.

Bug
`cat examples/pi/pi-intel.yaml`
`cat examples/pi/pi-mpich.yaml`
both fail with `No such file or directory`

`kubectl kustomize base | kubectl apply -f -`
also points to a `base/` dir that is not in this repo.

Fix
Use `examples/v2beta1/pi/...` and `manifests/overlays/kubeflow` instead.

Repro
Run those commands from repo root.

Related #596
