### PR TITLE
fix: honor cluster-domain in worker DNS search paths

### DIFF
--- a/pkg/controller/mpi_job_controller.go
+++ b/pkg/controller/mpi_job_controller.go
@@ -1517,7 +1517,11 @@ func (c *MPIJobController) newWorker(mpiJob *kubeflow.MPIJob, index int) *corev1
 		podTemplate.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	// The Intel and MPICH implementations require workers to communicate with the launcher through its hostname.
-	searche := fmt.Sprintf("%s.%s.svc.cluster.local", mpiJob.Name, mpiJob.Namespace)
+	searchDomain := "%s.%s.svc.cluster.local"
+	if c.clusterDomain != "" {
+		searchDomain = fmt.Sprintf("%%s.%%s.svc.%s", c.clusterDomain)
+	}
+	searche := fmt.Sprintf(searchDomain, mpiJob.Name, mpiJob.Namespace)
 	if podTemplate.Spec.DNSConfig == nil {
 		podTemplate.Spec.DNSConfig = &corev1.PodDNSConfig{Searches: []string{searche}}
 	} else {

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -1581,10 +1581,11 @@ func TestWorkerReady(t *testing.T) {
 
 func TestNewLauncherAndWorker(t *testing.T) {
 	cases := map[string]struct {
-		job          kubeflow.MPIJob
-		workerIndex  int
-		wantLauncher batchv1.Job
-		wantWorker   corev1.Pod
+		job           kubeflow.MPIJob
+		clusterDomain string
+		workerIndex   int
+		wantLauncher  batchv1.Job
+		wantWorker    corev1.Pod
 	}{
 		"defaults": {
 			job: kubeflow.MPIJob{
@@ -2026,12 +2027,143 @@ func TestNewLauncherAndWorker(t *testing.T) {
 				},
 			},
 		},
+		"worker uses configured cluster domain for launcher hostname resolution": {
+			job: kubeflow.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-domain",
+					Namespace: "tenant-a",
+				},
+				Spec: kubeflow.MPIJobSpec{
+					MPIImplementation: kubeflow.MPIImplementationIntel,
+					MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec{
+						kubeflow.MPIReplicaTypeLauncher: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+						kubeflow.MPIReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			clusterDomain: "kube.local",
+			wantLauncher: batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-domain-launcher",
+					Namespace: "tenant-a",
+					Labels: map[string]string{
+						"app": "custom-domain",
+					},
+				},
+				Spec: batchv1.JobSpec{
+					PodReplacementPolicy: ptr.To(batchv1.Failed),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								kubeflow.OperatorNameLabel: kubeflow.OperatorName,
+								kubeflow.JobNameLabel:      "custom-domain",
+								kubeflow.JobRoleLabel:      "launcher",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Hostname:      "custom-domain-launcher",
+							Subdomain:     "custom-domain",
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+							Containers: []corev1.Container{
+								{
+									Env: joinEnvVars(
+										launcherEnvVars,
+										intelEnvVars,
+										corev1.EnvVar{Name: intelMPISlotsEnv, Value: "1"},
+										nvidiaDisableEnvVars),
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "ssh-auth", MountPath: "/root/.ssh"},
+										{Name: "mpi-job-config", MountPath: "/etc/mpi"},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "ssh-auth",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											DefaultMode: ptr.To[int32](0600),
+											SecretName:  "custom-domain-ssh",
+											Items:       sshVolumeItems,
+										},
+									},
+								},
+								{
+									Name: "mpi-job-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "custom-domain-config",
+											},
+											Items: configVolumeItems,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantWorker: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-domain-worker-0",
+					Namespace: "tenant-a",
+					Labels: map[string]string{
+						kubeflow.OperatorNameLabel: kubeflow.OperatorName,
+						kubeflow.JobNameLabel:      "custom-domain",
+						kubeflow.JobRoleLabel:      "worker",
+						kubeflow.ReplicaIndexLabel: "0",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Hostname:  "custom-domain-worker-0",
+					Subdomain: "custom-domain",
+					DNSConfig: &corev1.PodDNSConfig{
+						Searches: []string{"custom-domain.tenant-a.svc.kube.local"},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Command: []string{"/usr/sbin/sshd", "-De"},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "ssh-auth", MountPath: "/root/.ssh"},
+							},
+							Env: workerEnvVars,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "ssh-auth",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									DefaultMode: ptr.To[int32](0600),
+									SecretName:  "custom-domain-ssh",
+									Items:       sshVolumeItems,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			job := tc.job.DeepCopy()
 			scheme.Scheme.Default(job)
-			ctrl := &MPIJobController{}
+			ctrl := &MPIJobController{clusterDomain: tc.clusterDomain}
 			launcher := ctrl.newLauncherJob(job)
 			if !metav1.IsControlledBy(launcher, job) {
 				t.Errorf("Created launcher Pod is not controlled by Job")


### PR DESCRIPTION
small follow-up to #704 and #738.

`--cluster-domain` already updates the hostfile and `discover_hosts.sh`, but worker pods still get `dnsConfig.searches` hardcoded to `svc.cluster.local`.
That bites Intel MPI and MPICH, workers need to resolve the launcher hostname too.

Fix:
- use the configured cluster domain when building worker DNS search suffixes
- add a regression test for a custom-domain Intel MPI job

Repro:
1. Start the operator with `--cluster-domain=kube.local`
2. Create an Intel MPI or MPICH job
3. Inspect a worker pod with `kubectl get pod <worker> -o yaml`
4. Before this patch it has `dnsConfig.searches: ["<job>.<ns>.svc.cluster.local"]`
5. The launcher FQDN is `...svc.kube.local`, so hostname lookup is off and the job can break
