### PR TITLE
fix: allow zero workers when launcher acts as worker

### DIFF
--- a/pkg/apis/kubeflow/validation/validation.go
+++ b/pkg/apis/kubeflow/validation/validation.go
@@ -68,7 +68,7 @@ func validateMPIJobName(job *kubeflow.MPIJob) field.ErrorList {
 }
 
 func validateMPIJobSpec(spec *kubeflow.MPIJobSpec, path *field.Path) field.ErrorList {
-	errs := validateMPIReplicaSpecs(spec.MPIReplicaSpecs, path.Child("mpiReplicaSpecs"))
+	errs := validateMPIReplicaSpecs(spec.MPIReplicaSpecs, path.Child("mpiReplicaSpecs"), spec.RunLauncherAsWorker != nil && *spec.RunLauncherAsWorker)
 	if spec.SlotsPerWorker == nil {
 		errs = append(errs, field.Required(path.Child("slotsPerWorker"), "must have number of slots per worker"))
 	} else {
@@ -109,14 +109,14 @@ func validateRunPolicy(policy *kubeflow.RunPolicy, path *field.Path) field.Error
 	return errs
 }
 
-func validateMPIReplicaSpecs(replicaSpecs map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec, path *field.Path) field.ErrorList {
+func validateMPIReplicaSpecs(replicaSpecs map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec, path *field.Path, runLauncherAsWorker bool) field.ErrorList {
 	var errs field.ErrorList
 	if replicaSpecs == nil {
 		errs = append(errs, field.Required(path, "must have replica specs"))
 		return errs
 	}
 	errs = append(errs, validateLauncherReplicaSpec(replicaSpecs[kubeflow.MPIReplicaTypeLauncher], path.Key(string(kubeflow.MPIReplicaTypeLauncher)))...)
-	errs = append(errs, validateWorkerReplicaSpec(replicaSpecs[kubeflow.MPIReplicaTypeWorker], path.Key(string(kubeflow.MPIReplicaTypeWorker)))...)
+	errs = append(errs, validateWorkerReplicaSpec(replicaSpecs[kubeflow.MPIReplicaTypeWorker], path.Key(string(kubeflow.MPIReplicaTypeWorker)), runLauncherAsWorker)...)
 	return errs
 }
 
@@ -133,14 +133,19 @@ func validateLauncherReplicaSpec(spec *kubeflow.ReplicaSpec, path *field.Path) f
 	return errs
 }
 
-func validateWorkerReplicaSpec(spec *kubeflow.ReplicaSpec, path *field.Path) field.ErrorList {
+func validateWorkerReplicaSpec(spec *kubeflow.ReplicaSpec, path *field.Path, runLauncherAsWorker bool) field.ErrorList {
 	var errs field.ErrorList
 	if spec == nil {
 		return errs
 	}
 	errs = append(errs, validateReplicaSpec(spec, path)...)
-	if spec.Replicas != nil && *spec.Replicas <= 0 {
-		errs = append(errs, field.Invalid(path.Child("replicas"), *spec.Replicas, "must be greater than or equal to 1"))
+	if spec.Replicas != nil {
+		if *spec.Replicas < 0 {
+			errs = append(errs, field.Invalid(path.Child("replicas"), *spec.Replicas, "must be greater than or equal to 0"))
+		}
+		if *spec.Replicas == 0 && !runLauncherAsWorker {
+			errs = append(errs, field.Invalid(path.Child("replicas"), *spec.Replicas, "must be greater than or equal to 1 unless runLauncherAsWorker is true"))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/kubeflow/validation/validation_test.go
+++ b/pkg/apis/kubeflow/validation/validation_test.go
@@ -153,6 +153,42 @@ func TestValidateMPIJob(t *testing.T) {
 				},
 			},
 		},
+		"valid with zero workers when launcher acts as worker": {
+			job: kubeflow.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: kubeflow.MPIJobSpec{
+					RunLauncherAsWorker: ptr.To(true),
+					SlotsPerWorker:      ptr.To[int32](2),
+					RunPolicy: kubeflow.RunPolicy{
+						CleanPodPolicy: ptr.To(kubeflow.CleanPodPolicyRunning),
+					},
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: kubeflow.MPIImplementationOpenMPI,
+					MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec{
+						kubeflow.MPIReplicaTypeLauncher: {
+							Replicas:      ptr.To[int32](1),
+							RestartPolicy: kubeflow.RestartPolicyOnFailure,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+						kubeflow.MPIReplicaTypeWorker: {
+							Replicas:      ptr.To[int32](0),
+							RestartPolicy: kubeflow.RestartPolicyNever,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"empty job": {
 			wantErrs: field.ErrorList{
 				&field.Error{
@@ -373,6 +409,45 @@ func TestValidateMPIJob(t *testing.T) {
 				},
 			},
 		},
+		"invalid zero workers without launcher-as-worker": {
+			job: kubeflow.MPIJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: kubeflow.MPIJobSpec{
+					SlotsPerWorker: ptr.To[int32](2),
+					RunPolicy: kubeflow.RunPolicy{
+						CleanPodPolicy: ptr.To(kubeflow.CleanPodPolicyRunning),
+					},
+					SSHAuthMountPath:  "/root/.ssh",
+					MPIImplementation: kubeflow.MPIImplementationOpenMPI,
+					MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec{
+						kubeflow.MPIReplicaTypeLauncher: {
+							Replicas:      ptr.To[int32](1),
+							RestartPolicy: kubeflow.RestartPolicyOnFailure,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+						kubeflow.MPIReplicaTypeWorker: {
+							Replicas:      ptr.To[int32](0),
+							RestartPolicy: kubeflow.RestartPolicyNever,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErrs: field.ErrorList{{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.mpiReplicaSpecs[Worker].replicas",
+			}},
+		},
 		"invalid mpiJob name": {
 			job: kubeflow.MPIJob{
 				ObjectMeta: metav1.ObjectMeta{
@@ -411,5 +486,38 @@ func TestValidateMPIJob(t *testing.T) {
 				t.Errorf("Unexpected errors (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestValidateMPIJob_AllowsDefaultedZeroWorkersForLauncherAsWorker(t *testing.T) {
+	job := kubeflow.MPIJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: kubeflow.MPIJobSpec{
+			RunLauncherAsWorker: ptr.To(true),
+			MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec{
+				kubeflow.MPIReplicaTypeLauncher: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{}},
+						},
+					},
+				},
+				kubeflow.MPIReplicaTypeWorker: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeflow.SetDefaults_MPIJob(&job)
+
+	if errs := ValidateMPIJob(&job); len(errs) != 0 {
+		t.Fatalf("ValidateMPIJob returned unexpected errors after defaulting: %v", errs)
 	}
 }

--- a/pkg/controller/mpi_job_controller_test.go
+++ b/pkg/controller/mpi_job_controller_test.go
@@ -608,6 +608,49 @@ func TestAllResourcesCreated(t *testing.T) {
 	}
 }
 
+func TestAllResourcesCreatedForLauncherAsWorkerWithDefaultedZeroWorkers(t *testing.T) {
+	f := newFixture(t, "")
+	now := metav1.Now()
+	mpiJob := newMPIJob("foo", nil, &now, nil)
+	mpiJob.Spec.RunLauncherAsWorker = ptr.To(true)
+	mpiJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker] = &kubeflow.ReplicaSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "foo",
+						Image: "bar",
+					},
+				},
+			},
+		},
+	}
+	f.setUpMPIJob(mpiJob)
+
+	fmjc := f.newFakeMPIJobController()
+	mpiJobCopy := mpiJob.DeepCopy()
+	scheme.Scheme.Default(mpiJobCopy)
+	f.expectCreateServiceAction(newJobService(mpiJobCopy))
+	cfgMap := newConfigMap(mpiJobCopy, 0, "")
+	updateDiscoverHostsInConfigMap(cfgMap, mpiJobCopy, nil, "")
+	f.expectCreateConfigMapAction(cfgMap)
+	secret, err := newSSHAuthSecret(mpiJobCopy)
+	if err != nil {
+		t.Fatalf("Failed creating secret")
+	}
+	f.expectCreateSecretAction(secret)
+	f.expectCreateJobAction(fmjc.newLauncherJob(mpiJobCopy))
+
+	mpiJobCopy.Status.Conditions = []kubeflow.JobCondition{newCondition(kubeflow.JobCreated, corev1.ConditionTrue, mpiJobCreatedReason, "MPIJob default/foo is created.")}
+	mpiJobCopy.Status.ReplicaStatuses = map[kubeflow.MPIReplicaType]*kubeflow.ReplicaStatus{
+		kubeflow.MPIReplicaTypeLauncher: {},
+		kubeflow.MPIReplicaTypeWorker:   {},
+	}
+	f.expectUpdateMPIJobStatusAction(mpiJobCopy)
+
+	f.run(t.Context(), getKey(mpiJob, t))
+}
+
 func TestLauncherNotControlledByUs(t *testing.T) {
 	f := newFixture(t, "")
 	startTime := metav1.Now()

--- a/test/integration/mpi_job_controller_test.go
+++ b/test/integration/mpi_job_controller_test.go
@@ -180,6 +180,79 @@ func TestMPIJobSuccess(t *testing.T) {
 	}
 }
 
+func TestMPIJobRunLauncherAsWorkerWithDefaultedZeroWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s := newTestSetup(ctx, t)
+	startController(ctx, s.kClient, s.mpiClient, nil)
+
+	mpiJob := &kubeflow.MPIJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "job",
+			Namespace: s.namespace,
+		},
+		Spec: kubeflow.MPIJobSpec{
+			RunLauncherAsWorker: ptr.To(true),
+			RunPolicy: kubeflow.RunPolicy{
+				CleanPodPolicy: ptr.To(kubeflow.CleanPodPolicyRunning),
+			},
+			MPIReplicaSpecs: map[kubeflow.MPIReplicaType]*kubeflow.ReplicaSpec{
+				kubeflow.MPIReplicaTypeLauncher: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "main",
+									Image: "mpi-image",
+								},
+							},
+						},
+					},
+				},
+				kubeflow.MPIReplicaTypeWorker: {
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "main",
+									Image: "mpi-image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var err error
+	mpiJob, err = s.mpiClient.KubeflowV2beta1().MPIJobs(s.namespace).Create(ctx, mpiJob, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed sending job to apiserver: %v", err)
+	}
+
+	s.events.expect(eventForJob(corev1.Event{
+		Type:   corev1.EventTypeNormal,
+		Reason: "MPIJobCreated",
+	}, mpiJob))
+
+	workerPods, launcherJob := validateMPIJobDependencies(ctx, t, s.kClient, mpiJob, 0, nil)
+	if len(workerPods) != 0 {
+		t.Fatalf("expected no worker pods, got %d", len(workerPods))
+	}
+	if launcherJob == nil {
+		t.Fatal("expected launcher Job to be created")
+	}
+
+	mpiJob = validateMPIJobStatus(ctx, t, s.mpiClient, mpiJob, map[kubeflow.MPIReplicaType]*kubeflow.ReplicaStatus{
+		kubeflow.MPIReplicaTypeLauncher: {},
+		kubeflow.MPIReplicaTypeWorker:   {},
+	})
+	if !mpiJobHasCondition(mpiJob, kubeflow.JobCreated) {
+		t.Errorf("MPIJob missing Created condition")
+	}
+	s.events.verify(t)
+}
+
 func TestMPIJobWaitWorkers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)


### PR DESCRIPTION
small fix for a sneaky `runLauncherAsWorker` footgun.

if `runLauncherAsWorker: true` is used and the `Worker` spec omits `replicas`, defaulting sets worker replicas to `0`. reconcile then validates the defaulted job, hits `ValidationError`, and bails out, so the launcher Job never shows up.

this patch allows `Worker.replicas: 0` only for that mode. other zero worker cases still fail, so the old guardrail stays.

repro:
1. apply this:
```yaml
apiVersion: kubeflow.org/v2beta1
kind: MPIJob
metadata:
  name: repro
spec:
  runLauncherAsWorker: true
  runPolicy:
    cleanPodPolicy: Running
  mpiReplicaSpecs:
    Launcher:
      template:
        spec:
          containers:
          - name: main
            image: mpi-image
    Worker:
      template:
        spec:
          containers:
          - name: main
            image: mpi-image
```
2. on current `master`, the job gets a `ValidationError` event and no launcher Job is created
3. with this patch, the launcher Job, Service, ConfigMap and Secret are created, and there are no worker Pods, which is the intended path

tests:
- validation coverage for zero workers in launcher-as-worker mode
- controller reconcile regression test
- integration regression test
